### PR TITLE
docs: point quickstart at make up target

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ The `make up` target first runs `scripts/preflight_and_bootstrap.sh` in prefligh
 
 If you chose `br0`, the host will reboot once, then resume automatically:
 - pfSense VM defined with the `pfSense_config` ISO attached so first boot auto-imports `/opt/homelab/pfsense/config/config.xml`.
-- `make all` brings up Minikube + MetalLB + Traefik + cert-manager + Postgres + backups + AWX + Observability + Django + Flux.
+- `make up` orchestrates Minikube, MetalLB, Traefik, cert-manager, Postgres, backups, AWX, Observability, Django, and Flux end-to-end.
 
 A deeper walk-through of every subsystem, bootstrap dependency, and GitOps controller can be found in the [Architecture](architecture.md) guide. That page also includes Mermaid sequence/state diagrams that are rendered as part of the documentation build.
 


### PR DESCRIPTION
## Summary
- update the Day-1 Quickstart instructions to point at `make up`
- refresh the surrounding description of the bootstrap workflow and confirm no other docs reference the removed target

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cf1f27df3c83238eed13b4403599d0