### PR TITLE
docs: highlight pfSense serial installer requirement

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,12 @@ Welcome to the documentation portal for the Uranus homelab GitOps stack. This si
 git clone https://github.com/devadalberto/homelab_gitops.git
 cd homelab_gitops
 cp .env.example .env
-# Edit passwords, ranges, and mount paths if needed
+# Edit passwords, ranges, mount paths, and set PF_SERIAL_INSTALLER_PATH to the downloaded pfSense serial installer
 make up
 ```
+
+`.env.example` defaults to the serial image workflow. Override `PF_SERIAL_INSTALLER_PATH` with your local download location (or
+set `PF_ISO_PATH` instead if you must bootstrap from the VGA build) before running `make up`.
 
 The `make up` target first runs `scripts/preflight_and_bootstrap.sh` in preflight mode so host packages, kernel modules, and firewall rules are ready before Minikube is rebuilt. It then hands control to the combined bootstrap workflow in `scripts/uranus_homelab.sh` for cluster bring-up and application deployment.
 
@@ -41,7 +44,7 @@ virsh shutdown ${VM_NAME}    # skip if the VM has never been started
 ./pfsense/pf-bootstrap.sh    # reattach the refreshed ISO; rerun after edits to .env
 ```
 
-`pf-bootstrap.sh` swaps the ISO automatically for shut-off domains. If the VM is running, stop it first or run the `virsh change-media ${VM_NAME} sdb ${WORK_ROOT}/pfsense/config/pfSense-config.iso --insert --force --config` command manually after the shutdown completes.
+`pf-bootstrap.sh` swaps the ISO automatically for shut-off domains. If the VM is running, stop it first or run the `virsh change-media ${VM_NAME} sdb ${WORK_ROOT}/pfsense/config/pfSense-config.iso --insert --force --config` command manually after the shutdown completes. The helper re-reads `.env` on each invocation, so confirm `PF_SERIAL_INSTALLER_PATH` still references the serial installer download (or export `PF_ISO_PATH` when bootstrapping the VGA image) before triggering a refresh.
 
 ## Environment Variables and Mapping
 


### PR DESCRIPTION
## Summary
- call out PF_SERIAL_INSTALLER_PATH in the Day-1 Quickstart so operators point it at the downloaded pfSense serial installer
- document the default serial workflow and how to override it with PF_ISO_PATH when VGA media is required
- remind the pfSense refresh procedure to double-check the installer path before rerunning the bootstrap helper

## Testing
- make docs *(fails in strict mode because mkdocs aborts on existing navigation/link warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1f29d4f483239a707bd1be49e719