### PR TITLE
Clarify installer path handling and doc generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,9 @@ PG_STORAGE_SIZE=10Gi
 AWX_ADMIN_USER=admin
 DJ_IMAGE=hashicorp/http-echo:0.2.3
 # pfSense installer assets
+# PF_SERIAL_INSTALLER_PATH=/home/<user>/downloads/netgate-installer-amd64.img.gz
+# Update PF_SERIAL_INSTALLER_PATH to match the serial installer image you downloaded.
+# The automation accepts compressed archives (.img.gz or .iso.gz) and will decompress them if needed.
 PF_SERIAL_INSTALLER_PATH=/home/saitama/downloads/netgate-installer-amd64-serial.img.gz
 # Uncomment if you must fall back to the VGA installer image
 # PF_ISO_PATH=/home/saitama/downloads/netgate-installer-amd64.img.gz

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,12 @@ preflight:
 	sudo ./pfsense/pf-config-gen.sh --env-file "$(ENV_FILE)"
 	installer_path="$$(awk -F= '/^[[:space:]]*PF_SERIAL_INSTALLER_PATH[[:space:]]*=/ { val=$$2; gsub(/^[[:space:]]+|[[:space:]]+$$/, "", val); if (val != "") { print val; exit } } /^[[:space:]]*PF_ISO_PATH[[:space:]]*=/ { val=$$2; gsub(/^[[:space:]]+|[[:space:]]+$$/, "", val); if (val != "") { print val; exit } }' "$(ENV_FILE)")"; \
 	if [ -n "$$installer_path" ]; then \
+		if [ ! -f "$$installer_path" ] && [[ "$$installer_path" == *.gz ]]; then \
+			alt_path="$${installer_path%.gz}"; \
+			if [ -f "$$alt_path" ]; then \
+				installer_path="$$alt_path"; \
+			fi; \
+		fi; \
 		sudo ./pfsense/pf-bootstrap.sh --env-file "$(ENV_FILE)" --headless --installation-path "$$installer_path"; \
 	else \
 		sudo ./pfsense/pf-bootstrap.sh --env-file "$(ENV_FILE)" --headless; \

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ so pfSense, Minikube, and Flux start from a known-good foundation.
    - Fetch the pfSense CE serial image (`netgate-installer-amd64-serial.img.gz`) from Netgate and note its absolute path. The
      serial build avoids a VNC dependency, aligns with the default headless console configuration, and matches the defaults baked
      into `pfsense/pf-bootstrap.sh`.
+   - If the downloaded archive does not already match `netgate-installer-amd64-serial.img.gz`, either rename it or set
+     `PF_SERIAL_INSTALLER_PATH` in `.env` to the exact filename you downloaded. The automation accepts the `.img.gz` archive as is
+     (decompression to `.img` is optional—update the path if you extract it).
    - If you must use the VGA build, populate `PF_ISO_PATH` in `.env` and supply `--no-headless` when invoking `pf-bootstrap.sh`.
 
 6. **Create and populate `.env`.**
@@ -170,7 +173,9 @@ platform from a bare host to a reconciled Flux cluster without bouncing between 
    ```
    - Populate `.env` with your domain, LAN addressing, MetalLB pool, and pfSense installer details. Critical variables consumed
      by downstream scripts include `PF_SERIAL_INSTALLER_PATH` (or `PF_ISO_PATH` for the VGA build), `PF_HEADLESS`, `WORK_ROOT`,
-     `VM_NAME`, `DISK_SIZE_GB`, `RAM_MB`, `VCPUS`, `WAN_MODE`, and `WAN_NIC`.
+     `VM_NAME`, `DISK_SIZE_GB`, `RAM_MB`, `VCPUS`, `WAN_MODE`, and `WAN_NIC`. If your downloaded installer uses a different
+     filename, either rename it to `netgate-installer-amd64-serial.img.gz` or set `PF_SERIAL_INSTALLER_PATH` directly. You may
+     leave the `.img.gz` archive compressed (or extract it to `.img` and update the path accordingly).
    - `scripts/host-prep.sh` installs libvirt/KVM, Docker, Minikube, kubectl, helm, sops, and related tooling while enabling the
      `libvirtd` and `docker` services. Run it with sudo on Debian/Ubuntu hosts or replicate the package list manually on other
      distributions.
@@ -192,9 +197,9 @@ platform from a bare host to a reconciled Flux cluster without bouncing between 
    virsh start "${VM_NAME}"
    virsh console "${VM_NAME}"
    ```
-   - `PF_SERIAL_INSTALLER_PATH` should point at the downloaded `netgate-installer-amd64-serial.img.gz`; set `PF_ISO_PATH` if you
-     must use the VGA image (`netgate-installer-amd64.img.gz`) and pass `--no-headless` or export `PF_HEADLESS=false` to
-     re-enable VNC access.
+   - `PF_SERIAL_INSTALLER_PATH` should reference the pfSense serial installer you downloaded. Rename the archive to
+     `netgate-installer-amd64-serial.img.gz` or update `.env` with the actual filename (compressed `.img.gz` and `.iso.gz`
+     archives work without manual extraction, though you can extract to `.img` if preferred).
    - The bootstrapper relies on `.env` for VM sizing (`VCPUS`, `RAM_MB`, `DISK_SIZE_GB`), naming (`VM_NAME`), storage (`WORK_ROOT`),
      and network placement (`WAN_MODE`, `WAN_NIC`). It will decompress the installer if needed and guarantee the generated
      `pfSense-config.iso` remains attached on the secondary CD-ROM.
@@ -604,4 +609,5 @@ Keeping pfSense and MetalLB synchronized avoids overlapping leases and ensures D
 └── README.md                   # This document
 ```
 
-Additional documentation lives in `docs/`, including release notes (`docs/CHANGELOG.md`).
+Additional documentation lives in `docs/`, including release notes (`docs/CHANGELOG.md`). Run `make docs` to generate the MkDocs
+site and Mermaid diagrams in one pass (the `docs` target renders both via MkDocs and the Mermaid CLI helpers).

--- a/pfsense/pf-bootstrap.sh
+++ b/pfsense/pf-bootstrap.sh
@@ -643,7 +643,10 @@ main() {
   ensure_config_assets
 
   local installer
-  installer=$(discover_installer_path) || die ${EX_CONFIG} "Unable to locate pfSense installer. Provide --installation-path or set PF_SERIAL_INSTALLER_PATH/PF_ISO_PATH/PF_INSTALLER_DIR."
+  if ! installer=$(discover_installer_path); then
+    log_warn "No pfSense installer detected. Set PF_SERIAL_INSTALLER_PATH to the downloaded archive or rename it to match the expected netgate-installer-amd64-serial image."
+    die ${EX_CONFIG} "Unable to locate pfSense installer. Provide --installation-path or set PF_SERIAL_INSTALLER_PATH/PF_ISO_PATH/PF_INSTALLER_DIR."
+  fi
   log_info "Using pfSense installer at ${installer}"
   stage_installer_media "${installer}"
 


### PR DESCRIPTION
## Summary
- document how to point `PF_SERIAL_INSTALLER_PATH` at alternate installer filenames and note optional decompression in `.env.example` and the README
- make the `preflight` target respect any configured installer filename and fall back to an extracted `.img` when the archive is missing
- warn when `pf-bootstrap.sh` cannot locate installer media and call out that `make docs` builds the MkDocs site and Mermaid diagrams

## Testing
- `ENV_FILE=.env.test make preflight` *(fails in the container: missing xorriso/genisoimage/mkisofs and virt-install)*
- `make docs` *(fails in the container: MkDocs strict mode aborts on external Mermaid download and nav warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2418a6608323b7e7b9b06ba93760