### PR TITLE
Ensure pfSense config directory ownership

### DIFF
--- a/pfsense/pf-config-gen.sh
+++ b/pfsense/pf-config-gen.sh
@@ -20,6 +20,9 @@ else
   fi
 fi
 
+sudo mkdir -p /opt/homelab/pfsense/config
+sudo chown "$(id -u)":"$(id -g)" /opt/homelab/pfsense/config || true
+
 readonly EX_OK=0
 readonly EX_USAGE=64
 # shellcheck disable=SC2034


### PR DESCRIPTION
## Summary
- ensure the pfSense config generation script creates the config output directory
- adjust ownership of the config directory to the invoking user to avoid permission issues

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cf405804188323939882c785e437ec