### PR TITLE
Use configurable Minikube profile in cluster script

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ When bumping versions:
 2. Edit the Flux HelmReleases so the controller targets the same versions (for example, `k8s/addons/{metallb,traefik,cert-manager}/release.yaml`).
 3. Review scripts or manifests that reference those versions (such as the Makefile `db`/`obs` targets) to confirm they inherit the new values.
 4. Smoke test locally before merging:
-   - Recreate Minikube if necessary (`minikube delete -p uranus`).
+   - Recreate Minikube if necessary (`minikube delete -p "${LABZ_MINIKUBE_PROFILE:-uranus}"`).
    - Run `make k8s` to bring up the core addons with the pinned charts.
    - Execute `make db` and `make obs` to ensure the data and observability stacks install with the new chart versions.
    - Spot-check `helm list -A` and `kubectl get pods --all-namespaces` for healthy rollouts.

--- a/k8s/cluster-up.sh
+++ b/k8s/cluster-up.sh
@@ -4,17 +4,18 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 [[ -f "$ROOT/.env" ]] && source "$ROOT/.env" || source "$ROOT/.env.example"
 
 KUBERNETES_VERSION="${KUBERNETES_VERSION:-${LABZ_KUBERNETES_VERSION:-v1.31.3}}"
+LABZ_MINIKUBE_PROFILE="${LABZ_MINIKUBE_PROFILE:-uranus}"
 METALLB_CHART_VERSION="${METALLB_CHART_VERSION:-${METALLB_HELM_VERSION:-0.14.7}}"
 TRAEFIK_CHART_VERSION="${TRAEFIK_CHART_VERSION:-${TRAEFIK_HELM_VERSION:-27.0.2}}"
 CERT_MANAGER_CHART_VERSION="${CERT_MANAGER_CHART_VERSION:-${CERT_MANAGER_HELM_VERSION:-1.16.3}}"
 
-if ! minikube status --profile uranus >/dev/null 2>&1; then
-  minikube start --profile=uranus --driver=docker --container-runtime=containerd --cpus=4 --memory=8192 --kubernetes-version="${KUBERNETES_VERSION}"
+if ! minikube status --profile "${LABZ_MINIKUBE_PROFILE}" >/dev/null 2>&1; then
+  minikube start --profile="${LABZ_MINIKUBE_PROFILE}" --driver=docker --container-runtime=containerd --cpus=4 --memory=8192 --kubernetes-version="${KUBERNETES_VERSION}"
 fi
-kubectl config use-context uranus >/dev/null 2>&1 || true
+kubectl config use-context "${LABZ_MINIKUBE_PROFILE}" >/dev/null 2>&1 || true
 
-minikube -p uranus addons enable metrics-server >/dev/null 2>&1 || true
-minikube -p uranus addons enable storage-provisioner >/dev/null 2>&1 || true
+minikube -p "${LABZ_MINIKUBE_PROFILE}" addons enable metrics-server >/dev/null 2>&1 || true
+minikube -p "${LABZ_MINIKUBE_PROFILE}" addons enable storage-provisioner >/dev/null 2>&1 || true
 
 kubectl create ns metallb-system --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -n metallb-system -f - <<YAML


### PR DESCRIPTION
## Summary
- default LABZ_MINIKUBE_PROFILE to uranus when unset in cluster-up.sh
- reuse the resolved profile for minikube and kubectl calls
- document the profile-aware Minikube delete command in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf5b0175148323a42259045ccb91c1