### PR TITLE
Align Flux bootstrap assets with minikube path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ terraform.tfstate.d/
 
 # Flux bootstrap artifacts
 flux-system/
+!clusters/*/flux-system/
+!clusters/*/flux-system/**
 
 # SOPS / AGE secrets
 .sops/age.key

--- a/clusters/minikube/flux-system/gotk-sync.yaml
+++ b/clusters/minikube/flux-system/gotk-sync.yaml
@@ -1,0 +1,26 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  url: ssh://git@github.com/YOUR_GITHUB_USER/homelab_gitops
+  ref:
+    branch: main
+  secretRef:
+    name: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./clusters/minikube
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  validation: client

--- a/clusters/minikube/flux-system/kustomization.yaml
+++ b/clusters/minikube/flux-system/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./flux-system
-  - ../../k8s/base
+  - gotk-sync.yaml

--- a/flux/install.sh
+++ b/flux/install.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 FLUX_VERSION="2.3.0"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLUSTER_PATH="${CLUSTER_PATH:-clusters/minikube}"
+if [[ "$CLUSTER_PATH" = /* ]]; then
+  CLUSTER_ABS_PATH="$CLUSTER_PATH"
+else
+  CLUSTER_ABS_PATH="$REPO_ROOT/$CLUSTER_PATH"
+fi
 
 run_with_sudo_if_needed() {
   if "$@"; then
@@ -87,4 +94,4 @@ fi
 
 kubectl create ns flux-system --dry-run=client -o yaml | kubectl apply -f -
 flux install -n flux-system || true
-mkdir -p "$(dirname "$0")/clusters/uranus"
+mkdir -p "$CLUSTER_ABS_PATH"

--- a/infra/docs/BOOTSTRAP_NOTES.md
+++ b/infra/docs/BOOTSTRAP_NOTES.md
@@ -6,7 +6,7 @@
 2. Verify cluster:
    kubectl get nodes -o wide
 
-3. Flux install:
+3. Flux install (installs the CLI and the controllers in the cluster):
    * Option A - manual, pinned, and checksum verified:
 
      ```sh
@@ -24,17 +24,24 @@
 
      Verify with `flux version --client --short` and then run `flux check --pre`.
 
-   * Option B - automated script (performs the same verified install):
+   * Option B - automated script (performs the same verified install and ensures the target cluster path exists; override with `CLUSTER_PATH=...` if needed):
 
      ```sh
      ./flux/install.sh
      ```
 
-4. Flux bootstrap (example with GitHub):
-   flux bootstrap github \
-     --owner YOUR_GH_USER \
-     --repository homelab_gitops \
-     --branch main \
-     --path clusters/minikube
+4. Configure Flux to sync this repository path:
+   * Update `clusters/minikube/flux-system/gotk-sync.yaml` with your repository URL (adjust the sync path and/or the `CLUSTER_PATH` variable if you store manifests elsewhere).
+   * Apply the bootstrap manifests:
 
-5. Commit and push k8s manifests as you go; Flux will reconcile.
+     ```sh
+     kubectl apply -k clusters/minikube/flux-system
+     ```
+
+   * Confirm the sync objects once they are ready:
+
+     ```sh
+     flux get kustomizations
+     ```
+
+5. Commit and push Kubernetes manifests as you go; Flux will reconcile `clusters/minikube` automatically.


### PR DESCRIPTION
## Summary
- default the Flux install helper to the repo's `clusters/minikube` path while allowing overrides
- add committed Flux GitRepository and Kustomization manifests for the minikube cluster and track them in Git
- document the updated bootstrap workflow that applies the new manifests

## Testing
- not run (kubectl is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf5b0164708323ab5d1397ec0126ec