### PR TITLE
Remove empty app overlays and fix postgres patch

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -8,9 +8,4 @@ resources:
   - ../observability
   - ../data/postgres
   - ../apps/awx
-  - ../apps/pihole
-  - ../apps/nextcloud
-  - ../apps/jellyfin
-  - ../apps/bitwarden
-  - ../apps/homepage
   - ../apps/django-multiproject

--- a/k8s/data/postgres/kustomization.yaml
+++ b/k8s/data/postgres/kustomization.yaml
@@ -12,5 +12,8 @@ configMapGenerator:
       - values.yaml=../../../data/postgres/pg-values.yaml
 generatorOptions:
   disableNameSuffixHash: true
-patchesStrategicMerge:
-  - patches/pg-values-namespace.yaml
+patches:
+  - path: patches/pg-values-namespace.yaml
+    target:
+      kind: ConfigMap
+      name: pg-values


### PR DESCRIPTION
## Summary
- remove the placeholder Pi-hole, Nextcloud, Jellyfin, Bitwarden, and Homepage overlays from the base kustomization so Flux no longer tries to apply no-op resources
- update the Postgres overlay to the new `patches` format so the namespace patch continues to apply when building locally with Flux

## Testing
- flux build kustomization base --path=./k8s/base --kustomization-file=/tmp/base-flux-kustomization.yaml --dry-run


------
https://chatgpt.com/codex/tasks/task_e_68cf5b02696883238e75aae8ee4ba306