### PR TITLE
Update pf.install to pass env file flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ preflight: pf.install
         ./scripts/preflight_and_bootstrap.sh $(COMMON_ARGS) $(DELETE_ARG) --preflight-only
 
 pf.install:
-        bash ./scripts/pf-vm-install.sh "$(ENV_FILE)"
+	bash ./scripts/pf-vm-install.sh --env-file "$(ENV_FILE)"
 
 bootstrap: preflight
 	./scripts/uranus_nuke_and_bootstrap.sh $(COMMON_ARGS) $(DELETE_ARG) $(HOLD_PORT_FORWARD_ARG)


### PR DESCRIPTION
## Summary
- update the pf.install recipe to invoke pf-vm-install with the --env-file option so the installer loads the configured environment

## Testing
- make pf.install *(fails: Makefile expects a tab at line 82 in pre-existing block)*
- bash ./scripts/pf-vm-install.sh --env-file .env *(fails: missing virsh, virt-install, qemu-img, ip on container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfac3a36388323865b0264422ffd78