### PR TITLE
Update pfSense env example defaults for sed parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,13 +45,13 @@ WAN_MODE=br0
 # pfSense LAN bridge defaults to an isolated host-only bridge. Leave
 # PF_LAN_BRIDGE empty to allow autodetection, or set it explicitly if you
 # rename the bridge so the libvirt network and VM wiring remain consistent.
-PF_VM_NAME="pfsense-uranus"
-PF_LAN_BRIDGE=""
-PF_OSINFO="freebsd14.2"
-PF_QCOW2_PATH="/var/lib/libvirt/images/pfsense-uranus.qcow2"
-PF_QCOW2_SIZE_GB="20"
-PF_INSTALLER_SRC="$HOME/downloads/netgate-installer-amd64.img.gz"
-PF_INSTALLER_DEST="/var/lib/libvirt/images/netgate-installer-amd64.img"
+PF_VM_NAME=pfsense-uranus
+PF_LAN_BRIDGE=
+PF_OSINFO=freebsd14.2
+PF_QCOW2_PATH=/var/lib/libvirt/images/pfsense-uranus.qcow2
+PF_QCOW2_SIZE_GB=20
+PF_INSTALLER_SRC=$HOME/downloads/netgate-installer-amd64.img.gz
+PF_INSTALLER_DEST=/var/lib/libvirt/images/netgate-installer-amd64.img
 LAB_CLUSTER_SUB=lab-minikube.labz.home.arpa
 TRAEFIK_LOCAL_IP=10.10.0.240
 WORK_ROOT=/opt/homelab


### PR DESCRIPTION
## Summary
- remove the surrounding quotes from pfSense-related defaults in `.env.example`
- leave empty placeholders as bare `KEY=` assignments so sed parsing returns empty strings

## Testing
- make -n preflight -f <(python - <<'PY'
with open('Makefile') as f:
    for line in f:
        if line.startswith('        '):
            line='\t'+line[8:]
        print(line, end='')
PY
)


------
https://chatgpt.com/codex/tasks/task_e_68cfac54422c83238a42288f3f2b97d2