### PR TITLE
Handle gzipped pfSense installer staging

### DIFF
--- a/scripts/pf-vm-install.sh
+++ b/scripts/pf-vm-install.sh
@@ -215,9 +215,14 @@ prepare_installer() {
   info "Using installer source: ${PF_INSTALLER_SRC}"
   if [[ "${src}" == *.gz ]]; then
     tmp="$(mktemp)"
-    gunzip -c "${src}" > "${tmp}"
-    sync_file "${tmp}" "${dest}" "Installer"
-    rm -f "${tmp}"
+    (
+      trap 'rm -f "${tmp}"' EXIT
+      info "Decompressing installer archive to ${dest}"
+      gunzip -c "${src}" > "${tmp}"
+      sudo install -d "$(dirname "${dest}")"
+      sudo rm -f "${dest}"
+      sudo install -m 0644 "${tmp}" "${dest}"
+    )
   else
     sync_file "${src}" "${dest}" "Installer"
   fi


### PR DESCRIPTION
## Summary
- decompress gzipped pfSense installers to their destination image path before invoking virt-install
- ensure stale destination files are removed and temporary staging files are cleaned up

## Testing
- PF_INSTALLER_SRC=/tmp/dummy-installer.img.gz PF_INSTALLER_DEST=/tmp/test-installer.img PF_QCOW2_PATH=/tmp/test.qcow2 PF_WAN_BRIDGE=lo PF_LAN_BRIDGE=lo make pf.install *(fails: Missing dependency: virsh)*

------
https://chatgpt.com/codex/tasks/task_e_68d08550f4cc8323bea17c12172205eb