### PR TITLE
Update .env example for pfSense serial installer guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,11 +21,19 @@ CERT_MANAGER_HELM_VERSION=1.16.3
 LABZ_POSTGRES_HELM_VERSION=16.2.6
 LABZ_KPS_HELM_VERSION=65.5.0
 
-# LAN/CIDR used by this lab (align to existing repo vars below)
+# LAN network configuration used by this lab (align to existing repo vars below)
 LAN_CIDR=10.10.0.0/24
 LAN_GW_IP=10.10.0.1
-DHCP_FROM=10.10.0.100
-DHCP_TO=10.10.0.200
+LAN_DHCP_FROM=10.10.0.100
+LAN_DHCP_TO=10.10.0.200
+
+# pfSense bridges (WAN ties into the host uplink; LAN defaults to host-only)
+# Set PF_WAN_BRIDGE to the host bridge that carries your WAN uplink (br0 is
+# typical when bridging a physical NIC).
+PF_WAN_BRIDGE=br0
+# Leave PF_LAN_BRIDGE empty to allow autodetection, or set it explicitly if you
+# rename the bridge so the libvirt network and VM wiring remain consistent.
+PF_LAN_BRIDGE=
 
 # MetalLB range (use this and also keep start/end for legacy)
 LABZ_METALLB_RANGE=10.10.0.240-10.10.0.250
@@ -40,18 +48,15 @@ LABZ_REDIS_PASSWORD=change-me
 LABZ_PHP_UPLOAD_LIMIT=2G
 
 # Legacy/infra (preserve for other stacks; do not remove)
+# WAN_NIC is the physical uplink interface that feeds the WAN bridge.
 WAN_NIC=eno1
+# WAN_MODE selects how the WAN side is provisioned (br0 creates/uses a Linux
+# bridge; set to macvtap to skip bridge management).
 WAN_MODE=br0
-# pfSense LAN bridge defaults to an isolated host-only bridge. Leave
-# PF_LAN_BRIDGE empty to allow autodetection, or set it explicitly if you
-# rename the bridge so the libvirt network and VM wiring remain consistent.
 PF_VM_NAME=pfsense-uranus
-PF_LAN_BRIDGE=
 PF_OSINFO=freebsd14.2
 PF_QCOW2_PATH=/var/lib/libvirt/images/pfsense-uranus.qcow2
 PF_QCOW2_SIZE_GB=20
-PF_INSTALLER_SRC="$HOME/downloads/netgate-installer-amd64.img.gz"
-PF_INSTALLER_DEST=/var/lib/libvirt/images/netgate-installer-amd64.img
 LAB_CLUSTER_SUB=lab-minikube.labz.home.arpa
 TRAEFIK_LOCAL_IP=10.10.0.240
 WORK_ROOT=/opt/homelab
@@ -59,10 +64,11 @@ PG_BACKUP_HOSTPATH=/opt/homelab/backups
 PG_STORAGE_SIZE=10Gi
 AWX_ADMIN_USER=admin
 DJ_IMAGE=hashicorp/http-echo:0.2.3
+
 # pfSense installer assets
-# Download the pfSense CE serial installer and set PF_INSTALLER_SRC to its
-# absolute path. The automation accepts compressed archives (.img.gz) and will
-# decompress them into PF_INSTALLER_DEST if needed.
-# Example:
-# PF_INSTALLER_SRC=/home/<user>/Downloads/netgate-installer-amd64.img.gz
+# Download the pfSense CE serial installer and point PF_SERIAL_INSTALLER_PATH at
+# the archive (.img or .img.gz). Legacy automation still honors
+# PF_INSTALLER_SRC/PF_INSTALLER_DEST if you need to fall back to the previous
+# variable names.
+PF_SERIAL_INSTALLER_PATH="$HOME/Downloads/netgate-installer-amd64-serial.img.gz"
 PF_HEADLESS=true


### PR DESCRIPTION
## Summary
- extend the LAN sample configuration to include LAN_DHCP_* placeholders and document pfSense WAN/LAN bridge usage
- replace the legacy PF_INSTALLER_SRC/PF_INSTALLER_DEST block with PF_SERIAL_INSTALLER_PATH guidance while noting fallback behavior

## Testing
- make check.env ENV_FILE=.env.example

------
https://chatgpt.com/codex/tasks/task_e_68d089f33b30832389758f7593378057