### PR TITLE
Add Bats-based tests for homelab bootstrap validation

### DIFF
--- a/.github/workflows/gitops-ci.yml
+++ b/.github/workflows/gitops-ci.yml
@@ -66,10 +66,25 @@ jobs:
       - name: Run kubeconform
         run: pre-commit run --all-files kubeconform
 
+  tests:
+    name: Homelab tests
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run shell test suite
+        run: make test
+
   validate:
     name: Validate GitOps Manifests
     runs-on: ubuntu-latest
-    needs: lint
+    needs:
+      - lint
+      - tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ SHELL := /bin/bash
 
 ENV_FILE ?= ./.env
 PF_VM_NAME ?= pfsense-uranus
+BATS ?= tests/vendor/bats-core/bin/bats
 
 .PHONY: help
 help:
 	@echo "Targets:"
+	@echo "  test            - Run repository test suite"
 	@echo "  up              - Run full bootstrap: pfSense + Kubernetes + status"
 	@echo "  net.ensure      - Ensure WAN/LAN bridges are present"
 	@echo "  preflight       - Ensure pfSense VM is running & IPs sane"
@@ -86,3 +88,9 @@ status:
 .PHONY: up
 up: net.ensure preflight pf.config pf.install pf.ztp pf.smoketest k8s.up k8s.smoketest status
 	@echo "Homelab bootstrap complete."
+.PHONY: test
+test:
+	@echo "Running Bats test suite..."
+	@$(BATS) tests/bats
+	@./scripts/tests/retry_test.sh
+

--- a/scripts/preflight_and_bootstrap.sh
+++ b/scripts/preflight_and_bootstrap.sh
@@ -1090,4 +1090,6 @@ main() {
   log_info "Preflight and bootstrap completed"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/tests/bats/env_schema.bats
+++ b/tests/bats/env_schema.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  homelab_test_setup
+  homelab_load_preflight
+  homelab_load_env_file "${REPO_ROOT}/.env.example"
+}
+
+@test ".env example exports bootstrap essentials" {
+  assert_not_empty "${LABZ_DOMAIN}" "LABZ_DOMAIN"
+  assert_not_empty "${LABZ_MINIKUBE_PROFILE}" "LABZ_MINIKUBE_PROFILE"
+  assert_not_empty "${LAN_CIDR}" "LAN_CIDR"
+  assert_not_empty "${METALLB_POOL_START}" "METALLB_POOL_START"
+  assert_not_empty "${METALLB_POOL_END}" "METALLB_POOL_END"
+  assert_not_empty "${LABZ_METALLB_RANGE}" "LABZ_METALLB_RANGE"
+  assert_not_empty "${TRAEFIK_LOCAL_IP}" "TRAEFIK_LOCAL_IP"
+  assert_equal "${METALLB_POOL_START}-${METALLB_POOL_END}" "${LABZ_METALLB_RANGE}"
+}
+
+@test "MetalLB start/end reside within the LAN CIDR" {
+  run ip_in_cidr "${METALLB_POOL_START}" "${LAN_CIDR}"
+  assert_success
+  assert_equal "1" "${output}" 
+
+  run ip_in_cidr "${METALLB_POOL_END}" "${LAN_CIDR}"
+  assert_success
+  assert_equal "1" "${output}"
+
+  run ip_between "${TRAEFIK_LOCAL_IP}" "${METALLB_POOL_START}" "${METALLB_POOL_END}"
+  assert_success
+  assert_equal "1" "${output}"
+}

--- a/tests/bats/metallb_range.bats
+++ b/tests/bats/metallb_range.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  homelab_test_setup
+  homelab_load_preflight
+}
+
+@test "select_metallb_pool prefers the 240-250 range when available" {
+  NETWORK_ADDR=10.10.0.20
+  NETWORK_CIDR=10.10.0.0/24
+  range_log="${BATS_TEST_TMPDIR}/range_calls"
+  range_available() {
+    printf '%s-%s\n' "$1" "$2" >>"${range_log}"
+    return 0
+  }
+
+  select_metallb_pool
+
+  assert_equal "10.10.0.240" "${METALLB_POOL_START}"
+  assert_equal "10.10.0.250" "${METALLB_POOL_END}"
+  assert_equal "${METALLB_POOL_START}-${METALLB_POOL_END}" "${LABZ_METALLB_RANGE}"
+  [[ -f "${range_log}" ]] || fail "range_available was not invoked"
+}
+
+@test "select_metallb_pool falls back when preferred range is busy" {
+  NETWORK_ADDR=10.10.0.20
+  NETWORK_CIDR=10.10.0.0/24
+  range_log="${BATS_TEST_TMPDIR}/range_calls"
+  call_count=0
+  range_available() {
+    printf '%s-%s\n' "$1" "$2" >>"${range_log}"
+    ((call_count++))
+    if (( call_count == 1 )); then
+      return 1
+    fi
+    return 0
+  }
+
+  select_metallb_pool
+
+  assert_equal "10.10.0.249" "${METALLB_POOL_START}"
+  assert_equal "10.10.0.254" "${METALLB_POOL_END}"
+  assert_equal "2" "${call_count}"
+}
+
+@test "adapt_address_pools recalculates when previous pool leaves the subnet" {
+  NETWORK_ADDR=10.10.0.42
+  NETWORK_CIDR=10.10.0.0/24
+  PREV_METALLB_START=10.20.0.5
+  PREV_METALLB_END=10.20.0.15
+  PREV_TRAEFIK_IP=10.20.0.5
+  METALLB_POOL_START=""
+  METALLB_POOL_END=""
+  TRAEFIK_LOCAL_IP=""
+  range_available() { return 0; }
+
+  adapt_address_pools
+
+  assert_equal "10.10.0.240" "${METALLB_POOL_START}"
+  assert_equal "10.10.0.250" "${METALLB_POOL_END}"
+  assert_equal "${METALLB_POOL_START}-${METALLB_POOL_END}" "${LABZ_METALLB_RANGE}"
+  assert_equal "${METALLB_POOL_START}" "${TRAEFIK_LOCAL_IP}"
+}

--- a/tests/bats/no_vga.bats
+++ b/tests/bats/no_vga.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  homelab_test_setup
+}
+
+@test "pfSense libvirt domain XML remains headless" {
+  local xml
+  xml=$(homelab_fixture "libvirt/pfsense-headless.xml")
+  [[ -f ${xml} ]] || fail "Fixture not found: ${xml}"
+
+  run python3 - "${xml}" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+path = sys.argv[1]
+root = ET.parse(path).getroot()
+issues = []
+graphics = root.findall('./devices/graphics')
+if graphics:
+    issues.append('graphics elements present')
+video = root.findall('./devices/video')
+if video:
+    issues.append('video devices present')
+consoles = root.findall('./devices/console')
+if not consoles:
+    issues.append('console element missing')
+else:
+    serial_targets = [c.find('target') for c in consoles]
+    if not all(t is not None and t.get('type') == 'serial' for t in serial_targets):
+        issues.append('console target not serial')
+serials = root.findall('./devices/serial')
+if not serials:
+    issues.append('serial element missing')
+else:
+    if not any(s.get('type') == 'pty' for s in serials):
+        issues.append('expected pty-backed serial console')
+if issues:
+    print('; '.join(issues))
+    sys.exit(1)
+PY
+  assert_success
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+if [[ -z ${REPO_ROOT:-} ]]; then
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
+_common_loaded=0
+_preflight_loaded=0
+
+homelab_test_setup() {
+  homelab_reset_env
+}
+
+homelab_reset_env() {
+  local vars=(
+    LABZ_DOMAIN LABZ_TRAEFIK_HOST LABZ_NEXTCLOUD_HOST LABZ_JELLYFIN_HOST
+    LABZ_METALLB_RANGE METALLB_POOL_START METALLB_POOL_END TRAEFIK_LOCAL_IP
+    LAN_CIDR LAN_GW_IP DHCP_FROM DHCP_TO
+    PREV_METALLB_START PREV_METALLB_END PREV_TRAEFIK_IP
+    NETWORK_ADDR NETWORK_CIDR NETWORK_PREFIX NETWORK_IFACE NETWORK_GW NETWORK_CLASS NETWORK_MTU
+  )
+  local var
+  for var in "${vars[@]}"; do
+    unset "${var}"
+  done
+}
+
+homelab_load_common() {
+  if [[ ${_common_loaded} -eq 0 ]]; then
+    # shellcheck source=../../scripts/lib/common.sh
+    source "${REPO_ROOT}/scripts/lib/common.sh"
+    _common_loaded=1
+  fi
+}
+
+homelab_load_preflight() {
+  if [[ ${_preflight_loaded} -eq 0 ]]; then
+    local previous_opts
+    previous_opts=$(set +o)
+    # shellcheck source=../../scripts/preflight_and_bootstrap.sh
+    source "${REPO_ROOT}/scripts/preflight_and_bootstrap.sh"
+    eval "${previous_opts}"
+    _preflight_loaded=1
+  fi
+}
+
+homelab_load_env_file() {
+  local env_file="$1"
+  homelab_load_common
+  if [[ ! -f ${env_file} ]]; then
+    printf 'Environment file not found: %s\n' "${env_file}" >&2
+    return 1
+  fi
+  homelab_reset_env
+  load_env "${env_file}"
+}
+
+homelab_fixture() {
+  local rel_path="$1"
+  printf '%s/%s\n' "${REPO_ROOT}/tests/fixtures" "${rel_path}"
+}
+
+assert_success() {
+  if [[ ${status:-0} -ne 0 ]]; then
+    printf 'Expected success but status=%s\nOutput:%s\n' "${status}" "${output:-}" >&2
+    return 1
+  fi
+}
+
+assert_failure() {
+  if [[ ${status:-0} -eq 0 ]]; then
+    printf 'Expected failure but status=%s\nOutput:%s\n' "${status}" "${output:-}" >&2
+    return 1
+  fi
+}
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  if [[ "${expected}" != "${actual}" ]]; then
+    printf 'Expected %s but found %s\n' "${expected}" "${actual}" >&2
+    return 1
+  fi
+}
+
+assert_not_empty() {
+  local value="$1"
+  local label="$2"
+  if [[ -z ${value} ]]; then
+    if [[ -n ${label} ]]; then
+      printf 'Expected %s to be set\n' "${label}" >&2
+    else
+      printf 'Expected value to be set\n' >&2
+    fi
+    return 1
+  fi
+}

--- a/tests/fixtures/libvirt/pfsense-headless.xml
+++ b/tests/fixtures/libvirt/pfsense-headless.xml
@@ -1,0 +1,60 @@
+<domain type='kvm'>
+  <name>pfsense-uranus</name>
+  <uuid>00000000-0000-4000-8000-000000000000</uuid>
+  <memory unit='MiB'>4096</memory>
+  <currentMemory unit='MiB'>4096</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-q35-8.1'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <cpu mode='host-passthrough'>
+    <topology sockets='1' cores='2' threads='1'/>
+  </cpu>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>restart</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source file='/var/lib/libvirt/images/netgate-installer-amd64.img'/>
+      <target dev='vda' bus='virtio'/>
+      <readonly/>
+      <boot order='1'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/pfsense-uranus.qcow2'/>
+      <target dev='vdb' bus='virtio'/>
+      <boot order='2'/>
+    </disk>
+    <controller type='usb' model='qemu-xhci'/>
+    <interface type='bridge'>
+      <source bridge='br0'/>
+      <model type='virtio'/>
+    </interface>
+    <interface type='bridge'>
+      <source bridge='pfsense-lan'/>
+      <model type='virtio'/>
+    </interface>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <channel type='unix'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+    </channel>
+    <input type='tablet' bus='usb'/>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+    </rng>
+  </devices>
+</domain>

--- a/tests/vendor/bats-core/LICENSE.md
+++ b/tests/vendor/bats-core/LICENSE.md
@@ -1,0 +1,53 @@
+Copyright (c) 2017 bats-core contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+* [bats-core] is a continuation of [bats]. Copyright for portions of the
+  bats-core project are held by Sam Stephenson, 2014 as part of the project
+  [bats], licensed under MIT:
+
+Copyright (c) 2014 Sam Stephenson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For details, please see the [version control history][commits].
+
+[bats-core]: https://github.com/bats-core/bats-core
+[bats]:https://github.com/sstephenson/bats
+[commits]:https://github.com/bats-core/bats-core/commits/master

--- a/tests/vendor/bats-core/bin/bats
+++ b/tests/vendor/bats-core/bin/bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Note: We first need to use POSIX's `[ ... ]' instead of Bash's `[[ ... ]]'
+# because this is the check for Bash, where the shell may not be Bash.  Once we
+# confirm that we are in Bash, we can use [[ ... ]] and (( ... )).  Note that
+# these [[ ... ]] and (( ... )) do not cause syntax errors in POSIX shells,
+# though they can be parsed differently.
+if [ -z "${BASH_VERSION-}" ] ||
+    [[ -z "${BASH_VERSINFO-}" ]] ||
+    ((BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 2)))
+then
+  printf 'bats: this program needs to be run by Bash >= 3.2\n' >&2
+  exit 1
+fi
+
+if command -v greadlink >/dev/null; then
+  bats_readlinkf() {
+    greadlink -f "$1"
+  }
+else
+  bats_readlinkf() {
+    readlink -f "$1"
+  }
+fi
+
+fallback_to_readlinkf_posix() {
+  bats_readlinkf() {
+    [ "${1:-}" ] || return 1
+    max_symlinks=40
+    CDPATH='' # to avoid changing to an unexpected directory
+
+    target=$1
+    [ -e "${target%/}" ] || target=${1%"${1##*[!/]}"} # trim trailing slashes
+    [ -d "${target:-/}" ] && target="$target/"
+
+    cd -P . 2>/dev/null || return 1
+    while [ "$max_symlinks" -ge 0 ] && max_symlinks=$((max_symlinks - 1)); do
+      if [ ! "$target" = "${target%/*}" ]; then
+        case $target in
+        /*) cd -P "${target%/*}/" 2>/dev/null || break ;;
+        *) cd -P "./${target%/*}" 2>/dev/null || break ;;
+        esac
+        target=${target##*/}
+      fi
+
+      if [ ! -L "$target" ]; then
+        target="${PWD%/}${target:+/}${target}"
+        printf '%s\n' "${target:-/}"
+        return 0
+      fi
+
+      # `ls -dl` format: "%s %u %s %s %u %s %s -> %s\n",
+      #   <file mode>, <number of links>, <owner name>, <group name>,
+      #   <size>, <date and time>, <pathname of link>, <contents of link>
+      # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ls.html
+      link=$(ls -dl -- "$target" 2>/dev/null) || break
+      target=${link#*" $target -> "}
+    done
+    return 1
+  }
+}
+
+if ! BATS_PATH=$(bats_readlinkf "${BASH_SOURCE[0]}" 2>/dev/null); then
+  fallback_to_readlinkf_posix
+  BATS_PATH=$(bats_readlinkf "${BASH_SOURCE[0]}")
+fi
+
+export BATS_SAVED_PATH=$PATH
+BATS_BASE_LIBDIR=lib # this will be patched with the true value in install.sh
+
+export BATS_ROOT=${BATS_PATH%/*/*}
+export -f bats_readlinkf
+exec env BATS_ROOT="$BATS_ROOT" BATS_LIBDIR="${BATS_BASE_LIBDIR:-lib}" "$BATS_ROOT/libexec/bats-core/bats" "$@"

--- a/tests/vendor/bats-core/lib/bats-core/common.bash
+++ b/tests/vendor/bats-core/lib/bats-core/common.bash
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+
+bats_prefix_lines_for_tap_output() {
+  while IFS= read -r line; do
+    printf '# %s\n' "$line" || break # avoid feedback loop when errors are redirected into BATS_OUT (see #353)
+  done
+  if [[ -n "$line" ]]; then
+    printf '# %s\n' "$line"
+  fi
+}
+
+function bats_replace_filename() {
+  local line
+  while read -r line; do
+    printf "%s\n" "${line//$BATS_TEST_SOURCE/$BATS_TEST_FILENAME}"
+  done
+  if [[ -n "$line" ]]; then
+    printf "%s\n" "${line//$BATS_TEST_SOURCE/$BATS_TEST_FILENAME}"
+  fi
+}
+
+bats_quote_code() { # <var> <code>
+  printf -v "$1" -- "%s%s%s" "$BATS_BEGIN_CODE_QUOTE" "$2" "$BATS_END_CODE_QUOTE"
+}
+
+bats_check_valid_version() {
+  if [[ ! $1 =~ [0-9]+.[0-9]+.[0-9]+ ]]; then
+    printf "ERROR: version '%s' must be of format <major>.<minor>.<patch>!\n" "$1" >&2
+    exit 1
+  fi
+}
+
+# compares two versions. Return 0 when version1 < version2
+bats_version_lt() { # <version1> <version2>
+  bats_check_valid_version "$1"
+  bats_check_valid_version "$2"
+
+  local -a version1_parts version2_parts
+  IFS=. read -ra version1_parts <<<"$1"
+  IFS=. read -ra version2_parts <<<"$2"
+
+  local -i i
+  for i in {0..2}; do
+    if ((version1_parts[i] < version2_parts[i])); then
+      return 0
+    elif ((version1_parts[i] > version2_parts[i])); then
+      return 1
+    fi
+  done
+  # if we made it this far, they are equal -> also not less then
+  return 2 # use other failing return code to distinguish equal from gt
+}
+
+# ensure a minimum version of bats is running or exit with failure
+bats_require_minimum_version() { # <required version>
+  local required_minimum_version=$1
+
+  if bats_version_lt "$BATS_VERSION" "$required_minimum_version"; then
+    printf "BATS_VERSION=%s does not meet required minimum %s\n" "$BATS_VERSION" "$required_minimum_version"
+    exit 1
+  fi
+
+  if bats_version_lt "$BATS_GUARANTEED_MINIMUM_VERSION" "$required_minimum_version"; then
+    BATS_GUARANTEED_MINIMUM_VERSION="$required_minimum_version"
+  fi
+}
+
+bats_binary_search() { # <search-value> <array-name>
+  if [[ $# -ne 2 ]]; then
+    printf "ERROR: bats_binary_search requires exactly 2 arguments: <search value> <array name>\n" >&2
+    return 2
+  fi
+
+  local -r search_value=$1 array_name=$2
+
+  # we'd like to test if array is set but we cannot distinguish unset from empty arrays, so we need to skip that
+
+  local start=0 mid end mid_value
+  # start is inclusive, end is exclusive ...
+  eval "end=\${#${array_name}[@]}"
+
+  # so start == end means empty search space
+  while ((start < end)); do
+    mid=$(((start + end) / 2))
+    eval "mid_value=\${${array_name}[$mid]}"
+    if [[ "$mid_value" == "$search_value" ]]; then
+      return 0
+    elif [[ "$mid_value" < "$search_value" ]]; then
+      # This branch excludes equality -> +1 to skip the mid element.
+      # This +1 also avoids endless recursion on odd sized search ranges.
+      start=$((mid + 1))
+    else
+      end=$mid
+    fi
+  done
+
+  # did not find it -> its not there
+  return 1
+}
+
+# store the values in ascending (string!) order in result array
+# Intended for short lists! (uses insertion sort)
+bats_sort() { # <result-array-name> <values to sort...>
+  local -r result_name=$1
+  shift
+
+  if (($# == 0)); then
+    eval "$result_name=()"
+    return 0
+  fi
+
+  local -a sorted_array=()
+  local -i i
+  while (( $# > 0 )); do # loop over input values
+    local current_value="$1"
+    shift
+    for ((i = ${#sorted_array[@]}; i >= 0; --i)); do # loop over output array from end
+      if (( i == 0 )) || [[ ${sorted_array[i - 1]} < $current_value ]]; then
+        # shift bigger elements one position to the end
+        sorted_array[i]=$current_value
+        break
+      else
+        # insert new element at (freed) desired location
+        sorted_array[i]=${sorted_array[i - 1]}
+      fi
+    done
+  done
+
+  eval "$result_name=(\"\${sorted_array[@]}\")"
+}
+
+# check if all search values (must be sorted!) are in the (sorted!) array
+# Intended for short lists/arrays!
+bats_all_in() { # <sorted-array> <sorted search values...>
+  local -r haystack_array=$1
+  shift
+
+  local -i haystack_length # just to appease shellcheck
+  eval "local -r haystack_length=\${#${haystack_array}[@]}"
+
+  local -i haystack_index=0         # initialize only here to continue from last search position
+  local search_value haystack_value # just to appease shellcheck
+  local -i i
+  for ((i = 1; i <= $#; ++i)); do
+    eval "local search_value=${!i}"
+    for (( ; haystack_index < haystack_length; ++haystack_index)); do
+      eval "local haystack_value=\${${haystack_array}[$haystack_index]}"
+      if [[ $haystack_value > "$search_value" ]]; then
+        # we passed the location this value would have been at -> not found
+        return 1
+      elif [[ $haystack_value == "$search_value" ]]; then
+        continue 2 # search value found  -> try the next one
+      fi
+    done
+    return 1 # we ran of the end of the haystack without finding the value!
+  done
+
+  # did not return from loop above -> all search values were found
+  return 0
+}
+
+# check if any search value (must be sorted!) is in the (sorted!) array
+# intended for short lists/arrays
+bats_any_in() { # <sorted-array> <sorted search values>
+  local -r haystack_array=$1
+  shift
+
+  local -i haystack_length # just to appease shellcheck
+  eval "local -r haystack_length=\${#${haystack_array}[@]}"
+
+  local -i haystack_index=0         # initialize only here to continue from last search position
+  local search_value haystack_value # just to appease shellcheck
+  local -i i
+  for ((i = 1; i <= $#; ++i)); do
+    eval "local search_value=${!i}"
+    for (( ; haystack_index < haystack_length; ++haystack_index)); do
+      eval "local haystack_value=\${${haystack_array}[$haystack_index]}"
+      if [[ $haystack_value > "$search_value" ]]; then
+        continue 2 # search value not in array! -> try next
+      elif [[ $haystack_value == "$search_value" ]]; then
+        return 0 # search value found
+      fi
+    done
+  done
+
+  # did not return from loop above -> no search value was found
+  return 1
+}
+
+bats_trim() {                                            # <output-variable> <string>
+  local -r bats_trim_ltrimmed=${2#"${2%%[![:space:]]*}"} # cut off leading whitespace
+  # shellcheck disable=SC2034 # used in eval!
+  local -r bats_trim_trimmed=${bats_trim_ltrimmed%"${bats_trim_ltrimmed##*[![:space:]]}"} # cut off trailing whitespace
+  eval "$1=\$bats_trim_trimmed"
+}
+
+# a helper function to work around unbound variable errors with ${arr[@]} on Bash 3
+bats_append_arrays_as_args() { # <array...> -- <command ...>
+  local -a trailing_args=()
+  while (($# > 0)) && [[ $1 != -- ]]; do
+    local array=$1
+    shift
+
+    if eval "(( \${#${array}[@]} > 0 ))"; then
+      eval "trailing_args+=(\"\${${array}[@]}\")"
+    fi
+  done
+  shift # remove -- separator
+
+  if (($# == 0)); then
+    printf "Error: append_arrays_as_args is missing a command or -- separator\n" >&2
+    return 1
+  fi
+
+  if ((${#trailing_args[@]} > 0)); then
+    "$@" "${trailing_args[@]}"
+  else
+    "$@"
+  fi
+}
+
+bats_format_file_line_reference() { # <output> <file> <line>
+  # shellcheck disable=SC2034 # will be used in subimplementation
+  local output="${1?}"
+  shift
+  "bats_format_file_line_reference_${BATS_LINE_REFERENCE_FORMAT?}" "$@"
+}
+
+bats_format_file_line_reference_comma_line() {
+  printf -v "$output" "%s, line %d" "$@"
+}
+
+bats_format_file_line_reference_colon() {
+  printf -v "$output" "%s:%d" "$@"
+}
+
+# approximate realpath without subshell
+bats_approx_realpath() { # <output-variable> <path>
+  local output=$1 path=$2
+  if [[ $path != /* ]]; then
+    path="$PWD/$path"
+  fi
+  # x/./y -> x/y
+  path=${path//\/.\//\/}
+  printf -v "$output" "%s" "$path"
+}
+
+bats_format_file_line_reference_uri() {
+  local filename=${1?} line=${2?}
+  bats_approx_realpath filename "$filename"
+  printf -v "$output" "file://%s:%d" "$filename" "$line"
+}
+
+# execute command with backed up path
+# to prevent path mocks from interfering with our internals
+bats_execute() { # <command...>
+  PATH="${BATS_SAVED_PATH?}" "$@"
+}

--- a/tests/vendor/bats-core/lib/bats-core/formatter.bash
+++ b/tests/vendor/bats-core/lib/bats-core/formatter.bash
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+# reads (extended) bats tap streams from stdin and calls callback functions for each line
+#
+# Segmenting functions
+# ====================
+# bats_tap_stream_plan <number of tests>                                      -> when the test plan is encountered
+# bats_tap_stream_suite <file name>                                           -> when a new file is begun WARNING: extended only
+# bats_tap_stream_begin <test index> <test name>                              -> when a new test is begun WARNING: extended only
+#
+# Test result functions
+# =====================
+# If timing was enabled, BATS_FORMATTER_TEST_DURATION will be set to their duration in milliseconds
+# bats_tap_stream_ok <test index> <test name>                                 -> when a test was successful
+# bats_tap_stream_not_ok <test index> <test name>                             -> when a test has failed. If the failure was due to a timeout,
+#                                                                                BATS_FORMATTER_TEST_TIMEOUT is set to the timeout duration in seconds
+# bats_tap_stream_skipped <test index> <test name> <skip reason>              -> when a test was skipped
+#
+# Context functions
+# =================
+# bats_tap_stream_comment <comment text without leading '# '> <scope>         -> when a comment line was encountered,
+#                                                                                scope tells the last encountered of plan, begin, ok, not_ok, skipped, suite
+# bats_tap_stream_unknown <full line> <scope>                                 -> when a line is encountered that does not match the previous entries,
+#                                                                                scope @see bats_tap_stream_comment
+# forwards all input as is, when there is no TAP test plan header
+function bats_parse_internal_extended_tap() {
+  local header_pattern='[0-9]+\.\.[0-9]+'
+  IFS= read -r header
+
+  if [[ "$header" =~ $header_pattern ]]; then
+    bats_tap_stream_plan "${header:3}"
+  else
+    # If the first line isn't a TAP plan, print it and pass the rest through
+    printf '%s\n' "$header"
+    exec cat
+  fi
+
+  ok_line_regexpr="ok ([0-9]+) (.*)"
+  skip_line_regexpr="ok ([0-9]+) (.*) # skip( (.*))?$"
+  timeout_line_regexpr="not ok ([0-9]+) (.*) # timeout after ([0-9]+)s$"
+  not_ok_line_regexpr="not ok ([0-9]+) (.*)"
+
+  timing_expr="in ([0-9]+)ms$"
+  local test_name begin_index last_begin_index try_index ok_index not_ok_index index scope
+  begin_index=0
+  last_begin_index=-1
+  try_index=0
+  index=0
+  scope=plan
+  while IFS= read -r line; do
+    unset BATS_FORMATTER_TEST_DURATION BATS_FORMATTER_TEST_TIMEOUT
+    case "$line" in
+    'begin '*) # this might only be called in extended tap output
+      scope=begin
+      begin_index=${line#begin }
+      begin_index=${begin_index%% *}
+      if [[ $begin_index == "$last_begin_index" ]]; then
+        (( ++try_index ))
+      else
+        try_index=0
+      fi
+      test_name="${line#begin "$begin_index" }"
+      bats_tap_stream_begin "$begin_index" "$test_name"
+      ;;
+    'ok '*)
+      ((++index))
+      if [[ "$line" =~ $ok_line_regexpr ]]; then
+        ok_index="${BASH_REMATCH[1]}"
+        test_name="${BASH_REMATCH[2]}"
+        if [[ "$line" =~ $skip_line_regexpr ]]; then
+          scope=skipped
+          test_name="${BASH_REMATCH[2]}" # cut off name before "# skip"
+          local skip_reason="${BASH_REMATCH[4]}"
+          if [[ "$test_name" =~ $timing_expr ]]; then
+            local BATS_FORMATTER_TEST_DURATION="${BASH_REMATCH[1]}"
+            test_name="${test_name% in "${BATS_FORMATTER_TEST_DURATION}"ms}"
+            bats_tap_stream_skipped "$ok_index" "$test_name" "$skip_reason"
+          else
+            bats_tap_stream_skipped "$ok_index" "$test_name" "$skip_reason"
+          fi
+        else
+          scope=ok
+          if [[ "$line" =~ $timing_expr ]]; then
+            local BATS_FORMATTER_TEST_DURATION="${BASH_REMATCH[1]}"
+            bats_tap_stream_ok "$ok_index" "${test_name% in "${BASH_REMATCH[1]}"ms}"
+          else
+            bats_tap_stream_ok "$ok_index" "$test_name"
+          fi
+        fi
+      else
+        printf "ERROR: could not match ok line: %s" "$line" >&2
+        exit 1
+      fi
+      ;;
+    'not ok '*)
+      ((++index))
+      scope=not_ok
+      if [[ "$line" =~ $not_ok_line_regexpr ]]; then
+        not_ok_index="${BASH_REMATCH[1]}"
+        test_name="${BASH_REMATCH[2]}"
+        if [[ "$line" =~ $timeout_line_regexpr ]]; then
+          not_ok_index="${BASH_REMATCH[1]}"
+          test_name="${BASH_REMATCH[2]}"
+          # shellcheck disable=SC2034 # used in bats_tap_stream_ok
+          local BATS_FORMATTER_TEST_TIMEOUT="${BASH_REMATCH[3]}"
+        fi
+        if [[ "$test_name" =~ $timing_expr ]]; then
+          # shellcheck disable=SC2034 # used in bats_tap_stream_ok
+          local BATS_FORMATTER_TEST_DURATION="${BASH_REMATCH[1]}"
+          test_name="${test_name% in "${BASH_REMATCH[1]}"ms}"
+        fi
+        bats_tap_stream_not_ok "$not_ok_index" "$test_name"
+      else
+        printf "ERROR: could not match not ok line: %s" "$line" >&2
+        exit 1
+      fi
+      ;;
+    '# '*)
+      bats_tap_stream_comment "${line:2}" "$scope"
+      ;;
+    '#')
+      bats_tap_stream_comment "" "$scope"
+      ;;
+    'suite '*)
+      scope=suite
+      # pass on the
+      bats_tap_stream_suite "${line:6}"
+      ;;
+    *)
+      bats_tap_stream_unknown "$line" "$scope"
+      ;;
+    esac
+  done
+}
+
+normalize_base_path() { # <target variable> <base path>
+  # the relative path root to use for reporting filenames
+  # this is mainly intended for suite mode, where this will be the suite root folder
+  local base_path="$2"
+  # use the containing directory when --base-path is a file
+  if [[ ! -d "$base_path" ]]; then
+    base_path="$(dirname "$base_path")"
+  fi
+  # get the absolute path
+  base_path="$(cd "$base_path" && pwd)"
+  # ensure the path ends with / to strip that later on
+  if [[ "${base_path}" != *"/" ]]; then
+    base_path="$base_path/"
+  fi
+  printf -v "$1" "%s" "$base_path"
+}

--- a/tests/vendor/bats-core/lib/bats-core/preprocessing.bash
+++ b/tests/vendor/bats-core/lib/bats-core/preprocessing.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+BATS_TMPNAME="$BATS_RUN_TMPDIR/bats.$$"
+BATS_PARENT_TMPNAME="$BATS_RUN_TMPDIR/bats.$PPID"
+# shellcheck disable=SC2034
+BATS_OUT="${BATS_TMPNAME}.out" # used in bats-exec-file
+
+bats_preprocess_source() {
+  # export to make it visible to bats_evaluate_preprocessed_source
+  # since the latter runs in bats-exec-test's bash while this runs in bats-exec-file's
+  export BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
+  # shellcheck disable=SC2153
+  CHECK_BATS_COMMENT_COMMANDS=1 "$BATS_ROOT/libexec/bats-core/bats-preprocess" "$BATS_TEST_FILENAME" >"$BATS_TEST_SOURCE"
+}
+
+bats_evaluate_preprocessed_source() {
+  if [[ -z "${BATS_TEST_SOURCE:-}" ]]; then
+    BATS_TEST_SOURCE="${BATS_PARENT_TMPNAME}.src"
+  fi
+  # Dynamically loaded user files provided outside of Bats.
+  # shellcheck disable=SC1090
+  source "$BATS_TEST_SOURCE"
+}

--- a/tests/vendor/bats-core/lib/bats-core/semaphore.bash
+++ b/tests/vendor/bats-core/lib/bats-core/semaphore.bash
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+bats_run_under_flock() {
+  flock "$BATS_SEMAPHORE_DIR" "$@"
+}
+
+bats_run_under_shlock() {
+      local lockfile="$BATS_SEMAPHORE_DIR/shlock.lock"
+      while ! shlock -p $$ -f "$lockfile"; do
+        sleep 1
+      done
+      # we got the lock now, execute the command
+      "$@"
+      local status=$?
+      # free the lock
+      rm -f "$lockfile"
+      return $status
+    }
+
+# setup the semaphore environment for the loading file
+bats_semaphore_setup() {
+  export -f bats_semaphore_get_free_slot_count
+  export -f bats_semaphore_acquire_while_locked
+  export BATS_SEMAPHORE_DIR="$BATS_RUN_TMPDIR/semaphores"
+
+  if command -v flock >/dev/null; then
+    BATS_LOCKING_IMPLEMENTATION=flock
+  elif command -v shlock >/dev/null; then
+    BATS_LOCKING_IMPLEMENTATION=shlock
+  else
+    printf "ERROR: flock/shlock is required for parallelization within files!\n" >&2
+    exit 1
+  fi
+}
+
+# $1 - output directory for stdout/stderr
+# $@ - command to run
+# run the given command in a semaphore
+# block when there is no free slot for the semaphore
+# when there is a free slot, run the command in background
+# gather the output of the command in files in the given directory
+bats_semaphore_run() {
+  local output_dir=$1
+  shift
+  local semaphore_slot
+  semaphore_slot=$(bats_semaphore_acquire_slot)
+  bats_semaphore_release_wrapper "$output_dir" "$semaphore_slot" "$@" &
+  printf "%d\n" "$!"
+}
+
+# $1 - output directory for stdout/stderr
+# $@ - command to run
+# this wraps the actual function call to install some traps on exiting
+bats_semaphore_release_wrapper() {
+  local output_dir="$1"
+  local semaphore_name="$2"
+  shift 2 # all other parameters will be use for the command to execute
+
+  # shellcheck disable=SC2064 # we want to expand the semaphore_name right now!
+  trap "status=$?; bats_semaphore_release_slot '$semaphore_name'; exit $status" EXIT
+
+  mkdir -p "$output_dir"
+  "$@" 2>"$output_dir/stderr" >"$output_dir/stdout"
+  local status=$?
+
+  # bash bug: the exit trap is not called for the background process
+  bats_semaphore_release_slot "$semaphore_name"
+  trap - EXIT # avoid calling release twice
+  return $status
+}
+
+bats_semaphore_acquire_while_locked() {
+  if [[ $(bats_semaphore_get_free_slot_count) -gt 0 ]]; then
+    local slot=0
+    while [[ -e "$BATS_SEMAPHORE_DIR/slot-$slot" ]]; do
+      ((++slot))
+    done
+    if [[ $slot -lt $BATS_SEMAPHORE_NUMBER_OF_SLOTS ]]; then
+      touch "$BATS_SEMAPHORE_DIR/slot-$slot" && printf "%d\n" "$slot" && return 0
+    fi
+  fi
+  return 1
+}
+
+# block until a semaphore slot becomes free
+# prints the number of the slot that it received
+bats_semaphore_acquire_slot() {
+  mkdir -p "$BATS_SEMAPHORE_DIR"
+  # wait for a slot to become free
+  # TODO: avoid busy waiting by using signals -> this opens op prioritizing possibilities as well
+  while true; do
+    # don't lock for reading, we are fine with spuriously getting no free slot
+    if [[ $(bats_semaphore_get_free_slot_count) -gt 0 ]]; then
+      bats_run_under_"$BATS_LOCKING_IMPLEMENTATION" \
+        bash -c bats_semaphore_acquire_while_locked \
+      && break
+    fi
+    sleep 1
+  done
+}
+
+bats_semaphore_release_slot() {
+  # we don't need to lock this, since only our process owns this file
+  # and freeing a semaphore cannot lead to conflicts with others
+  rm "$BATS_SEMAPHORE_DIR/slot-$1" # this will fail if we had not acquired a semaphore!
+}
+
+bats_semaphore_get_free_slot_count() {
+  # find might error out without returning something useful when a file is deleted,
+  # while the directory is traversed ->  only continue when there was no error
+  until used_slots=$(find "$BATS_SEMAPHORE_DIR" -name 'slot-*' 2>/dev/null | wc -l); do :; done
+  echo $((BATS_SEMAPHORE_NUMBER_OF_SLOTS - used_slots))
+}

--- a/tests/vendor/bats-core/lib/bats-core/test_functions.bash
+++ b/tests/vendor/bats-core/lib/bats-core/test_functions.bash
@@ -1,0 +1,515 @@
+#!/usr/bin/env bash
+
+# this must be called for each test file!
+_bats_test_functions_setup() { # <BATS_TEST_NUMBER>
+  BATS_TEST_DIRNAME="${BATS_TEST_FILENAME%/*}"
+  BATS_TEST_NAMES=()
+  # shellcheck disable=SC2034
+  BATS_TEST_NUMBER=${1?}
+}
+
+# shellcheck source=lib/bats-core/warnings.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/warnings.bash"
+
+# find_in_bats_lib_path echoes the first recognized load path to
+# a library in BATS_LIB_PATH or relative to BATS_TEST_DIRNAME.
+#
+# Libraries relative to BATS_TEST_DIRNAME take precedence over
+# BATS_LIB_PATH.
+#
+# Library load paths are recognized using find_library_load_path.
+#
+# If no library is found find_in_bats_lib_path returns 1.
+find_in_bats_lib_path() { # <return-var> <library-name>
+  local return_var="${1:?}"
+  local library_name="${2:?}"
+
+  local -a bats_lib_paths
+  IFS=: read -ra bats_lib_paths <<<"$BATS_LIB_PATH"
+
+  for path in "${bats_lib_paths[@]}"; do
+    if [[ -f "$path/$library_name" ]]; then
+      printf -v "$return_var" "%s" "$path/$library_name"
+      # A library load path was found, return
+      return 0
+    elif [[ -f "$path/$library_name/load.bash" ]]; then
+      printf -v "$return_var" "%s" "$path/$library_name/load.bash"
+      # A library load path was found, return
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# bats_internal_load expects an absolute path that is a library load path.
+#
+# If the library load path points to a file (a library loader) it is
+# sourced.
+#
+# If it points to a directory all files ending in .bash inside of the
+# directory are sourced.
+#
+# If the sourcing of the library loader or of a file in a library
+# directory fails bats_internal_load prints an error message and returns 1.
+#
+# If the passed library load path is not absolute or is not a valid file
+# or directory bats_internal_load prints an error message and returns 1.
+bats_internal_load() {
+  local library_load_path="${1:?}"
+
+  if [[ "${library_load_path:0:1}" != / ]]; then
+    printf "Passed library load path is not an absolute path: %s\n" "$library_load_path" >&2
+    return 1
+  fi
+
+  # library_load_path is a library loader
+  if [[ -f "$library_load_path" ]]; then
+    # shellcheck disable=SC1090
+    if ! source "$library_load_path"; then
+      printf "Error while sourcing library loader at '%s'\n" "$library_load_path" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  printf "Passed library load path is neither a library loader nor library directory: %s\n" "$library_load_path" >&2
+  return 1
+}
+
+# bats_load_safe accepts an argument called 'slug' and attempts to find and
+# source a library based on the slug.
+#
+# A slug can be an absolute path, a library name or a relative path.
+#
+# If the slug is an absolute path bats_load_safe attempts to find the library
+# load path using find_library_load_path.
+# What is considered a library load path is documented in the
+# documentation for find_library_load_path.
+#
+# If the slug is not an absolute path it is considered a library name or
+# relative path. bats_load_safe attempts to find the library load path using
+# find_in_bats_lib_path.
+#
+# If bats_load_safe can find a library load path it is passed to bats_internal_load.
+# If bats_internal_load fails bats_load_safe returns 1.
+#
+# If no library load path can be found bats_load_safe prints an error message
+# and returns 1.
+bats_load_safe() {
+  local slug="${1:?}"
+  if [[ ${slug:0:1} != / ]]; then # relative paths are relative to BATS_TEST_DIRNAME
+    slug="$BATS_TEST_DIRNAME/$slug"
+  fi
+
+  if [[ -f "$slug.bash" ]]; then
+    bats_internal_load "$slug.bash"
+    return $?
+  elif [[ -f "$slug" ]]; then
+    bats_internal_load "$slug"
+    return $?
+  fi
+
+  # loading from PATH (retained for backwards compatibility)
+  if [[ ! -f "$1" ]] && type -P "$1" >/dev/null; then
+    # shellcheck disable=SC1090
+    source "$1"
+    return $?
+  fi
+
+  # No library load path can be found
+  printf "bats_load_safe: Could not find '%s'[.bash]\n" "$slug" >&2
+  return 1
+}
+
+bats_load_library_safe() { # <slug>
+  local slug="${1:?}" library_path
+
+  # Check for library load paths in BATS_TEST_DIRNAME and BATS_LIB_PATH
+  if [[ ${slug:0:1} != / ]]; then
+    if ! find_in_bats_lib_path library_path "$slug"; then
+      printf "Could not find library '%s' relative to test file or in BATS_LIB_PATH\n" "$slug" >&2
+      return 1
+    fi
+  else
+    # absolute paths are taken as is
+    library_path="$slug"
+    if [[ ! -f "$library_path" ]]; then
+      printf "Could not find library on absolute path '%s'\n" "$library_path" >&2
+      return 1
+    fi
+  fi
+
+  bats_internal_load "$library_path"
+  return $?
+}
+
+# immediately exit on error, use bats_load_library_safe to catch and handle errors
+bats_load_library() { # <slug>
+  if ! bats_load_library_safe "$@"; then
+    exit 1
+  fi
+}
+
+# load acts like bats_load_safe but exits the shell instead of returning 1.
+load() {
+  if ! bats_load_safe "$@"; then
+    exit 1
+  fi
+}
+
+bats_redirect_stderr_into_file() {
+  "$@" 2>>"$bats_run_separate_stderr_file" # use >> to see collisions' content
+}
+
+bats_merge_stdout_and_stderr() {
+  "$@" 2>&1
+}
+
+# write separate lines from <input-var> into <output-array>
+bats_separate_lines() { # <output-array> <input-var>
+  local -r output_array_name="$1"
+  local -r input_var_name="$2"
+  local input="${!input_var_name}"
+  if [[ $keep_empty_lines ]]; then
+    local bats_separate_lines_lines=()
+    if [[ -n "$input" ]]; then # avoid getting an empty line for empty input
+      # remove one trailing \n if it exists to compensate its addition by <<<
+      input=${input%$'\n'}
+      while IFS= read -r line; do
+        bats_separate_lines_lines+=("$line")
+      done <<<"${input}"
+    fi
+    eval "${output_array_name}=(\"\${bats_separate_lines_lines[@]}\")"
+  else
+    # shellcheck disable=SC2034,SC2206
+    IFS=$'\n' read -d '' -r -a "$output_array_name" <<<"${!input_var_name}" || true # don't fail due to EOF
+  fi
+}
+
+bats_pipe() { # [-N] [--] command0 [ \| command1 [ \| command2 [...]]]
+  # This will run each command given, piping them appropriately.
+  # Meant to be used in combination with `run` helper to allow piped commands
+  # to be used.
+  # Note that `\|` must be used, not `|`.
+  # By default, the exit code of this command will be the last failure in the
+  # chain of piped commands (similar to `set -o pipefail`).
+  # Supplying -N (e.g. -0) will instead always use the exit code of the command
+  # at that position in the chain.
+  # --returned-status=N could be used as an alternative to -N. This also allows
+  # for negative values (which count from the end in reverse order).
+
+  local pipestatus_position=
+
+  # parse options starting with -
+  while [[ $# -gt 0 ]] && [[ $1 == -* ]]; do
+    case "$1" in
+    -[0-9]*)
+      pipestatus_position="${1#-}"
+      ;;
+    --returned-status*)
+      if [ "$1" = "--returned-status" ]; then
+        pipestatus_position="$2"
+        shift
+      elif [[ "$1" =~ ^--returned-status= ]]; then
+        pipestatus_position="${1#--returned-status=}"
+      else
+        printf "Usage error: unknown flag '%s'" "$1" >&2
+        return 1
+      fi
+      ;;
+    --)
+      shift # eat the -- before breaking away
+      break
+      ;;
+    *)
+      printf "Usage error: unknown flag '%s'" "$1" >&2
+      return 1
+      ;;
+    esac
+    shift
+  done
+
+  # parse and validate arguments, escape as necessary
+  local -a commands_and_args=("$@")
+  local -a escaped_args=()
+  local -i pipe_count=0
+  local -i previous_pipe_index=-1
+  local -i index=0
+  for (( index = 0; index < $#; index++ )); do
+    local current_command_or_arg="${commands_and_args[$index]}"
+    local escaped_arg="$current_command_or_arg"
+    if [[ "$current_command_or_arg" != '|' ]]; then
+      # escape args to protect them when eval'd (e.g. if they contain whitespace).
+      printf -v escaped_arg "%q" "$current_command_or_arg"
+    elif [ "$current_command_or_arg" = "|" ]; then
+      if [ "$index" -eq 0 ]; then
+        printf "Usage error: Cannot have leading \`\\|\`.\n" >&2
+        return 1
+      fi
+      if (( (previous_pipe_index + 1) >= index )); then
+        printf "Usage error: Cannot have consecutive \`\\|\`. Found at argument position '%s'.\n" "$index" >&2
+        return 1
+      fi
+      (( ++pipe_count ))
+      previous_pipe_index="$index"
+    fi
+    escaped_args+=("$escaped_arg")
+  done
+
+  if (( (previous_pipe_index > 0) && (previous_pipe_index == ($# - 1)) )); then
+    printf "Usage error: Cannot have trailing \`\\|\`.\n" >&2
+    return 1
+  fi
+
+  if (( pipe_count == 0 )); then
+    # Don't allow for no pipes. This might be a typo in the test,
+    # e.g. `run bats_pipe command0 | command1`
+    # instead of `run bats_pipe command0 \| command1`
+    # Unfortunately, we can't catch `run bats_pipe command0 \| command1 | command2`.
+    # But this check is better than just allowing no pipes.
+    printf "Usage error: No \`\\|\`s found. Is this an error?\n" >&2
+    return 1
+  fi
+
+  # there will be pipe_count + 1 entries in PIPE_STATUS (pipe_count number of \|'s between each entry).
+  # valid indices are [-(pipe_count + 1), pipe_count]
+  if [ -n "$pipestatus_position" ] && (( (pipestatus_position > pipe_count) || (-pipestatus_position > (pipe_count + 1)) )); then
+    printf "Usage error: Too large of -N argument (or --returned-status) given. Argument value: '%s'.\n" "$pipestatus_position" >&2
+    return 1
+  fi
+
+  # run commands and return appropriate pipe status
+  local -a __bats_pipe_eval_pipe_status=()
+  eval "${escaped_args[*]}" '; __bats_pipe_eval_pipe_status=(${PIPESTATUS[@]})'
+
+  local result_status=
+  if [ -z "$pipestatus_position" ]; then
+    # if we are performing default "last failure" behavior,
+    # iterate backwards through pipe_status to find the last error.
+    result_status=0
+    for index in "${!__bats_pipe_eval_pipe_status[@]}"; do
+      # OSX bash doesn't support negative indexing.
+      local backward_iter_index="$((${#__bats_pipe_eval_pipe_status[@]} - index - 1))"
+      local status_at_backward_iter_index="${__bats_pipe_eval_pipe_status[$backward_iter_index]}"
+      if (( status_at_backward_iter_index != 0 )); then
+        result_status="$status_at_backward_iter_index"
+        break;
+      fi
+    done
+  elif (( pipestatus_position >= 0 )); then
+    result_status="${__bats_pipe_eval_pipe_status[$pipestatus_position]}"
+  else
+    # Must use positive values for some bash's (like OSX).
+    local backward_iter_index="$((${#__bats_pipe_eval_pipe_status[@]} + pipestatus_position))"
+    result_status="${__bats_pipe_eval_pipe_status[$backward_iter_index]}"
+  fi
+
+  return "$result_status"
+}
+
+run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run...>
+  # This has to be restored on exit from this function to avoid leaking our trap INT into surrounding code.
+  # Non zero exits won't restore under the assumption that they will fail the test before it can be aborted,
+  # which allows us to avoid duplicating the restore code on every exit path
+  trap bats_interrupt_trap_in_run INT
+  local expected_rc=
+  local keep_empty_lines=
+  local output_case=merged
+  local has_flags=
+  # parse options starting with -
+  while [[ $# -gt 0 ]] && [[ $1 == -* || $1 == '!' ]]; do
+    has_flags=1
+    case "$1" in
+    '!')
+      expected_rc=-1
+      ;;
+    -[0-9]*)
+      expected_rc=${1#-}
+      if [[ $expected_rc =~ [^0-9] ]]; then
+        printf "Usage error: run: '-NNN' requires numeric NNN (got: %s)\n" "$expected_rc" >&2
+        return 1
+      elif [[ $expected_rc -gt 255 ]]; then
+        printf "Usage error: run: '-NNN': NNN must be <= 255 (got: %d)\n" "$expected_rc" >&2
+        return 1
+      fi
+      ;;
+    --keep-empty-lines)
+      keep_empty_lines=1
+      ;;
+    --separate-stderr)
+      output_case="separate"
+      ;;
+    --)
+      shift # eat the -- before breaking away
+      break
+      ;;
+    *)
+      printf "Usage error: unknown flag '%s'" "$1" >&2
+      return 1
+      ;;
+    esac
+    shift
+  done
+
+  if [[ -n $has_flags ]]; then
+    bats_warn_minimum_guaranteed_version "Using flags on \`run\`" 1.5.0
+  fi
+
+  local pre_command=
+
+  case "$output_case" in
+  merged) # redirects stderr into stdout and fills only $output/$lines
+    pre_command=bats_merge_stdout_and_stderr
+    ;;
+  separate) # splits stderr into own file and fills $stderr/$stderr_lines too
+    local bats_run_separate_stderr_file
+    bats_run_separate_stderr_file="$(mktemp "${BATS_TEST_TMPDIR}/separate-stderr-XXXXXX")"
+    pre_command=bats_redirect_stderr_into_file
+    ;;
+  esac
+
+  local origFlags="$-"
+  set +eET
+  if [[ $keep_empty_lines ]]; then
+    # 'output', 'status', 'lines' are global variables available to tests.
+    # preserve trailing newlines by appending . and removing it later
+    # shellcheck disable=SC2034
+    output="$(
+      "$pre_command" "$@"
+      status=$?
+      printf .
+      exit $status
+    )" && status=0 || status=$?
+    output="${output%.}"
+  else
+    # 'output', 'status', 'lines' are global variables available to tests.
+    # shellcheck disable=SC2034
+    output="$("$pre_command" "$@")" && status=0 || status=$?
+  fi
+
+  bats_separate_lines lines output
+
+  if [[ "$output_case" == separate ]]; then
+    # shellcheck disable=SC2034
+    read -d '' -r stderr <"$bats_run_separate_stderr_file" || true
+    bats_separate_lines stderr_lines stderr
+  fi
+
+  # shellcheck disable=SC2034
+  BATS_RUN_COMMAND="${*}"
+  set "-$origFlags"
+
+  bats_run_print_output() {
+    if [[ -n "$output" ]]; then
+      printf "%s\n" "$output"
+    fi
+    if [[ "$output_case" == separate && -n "$stderr" ]]; then
+      printf "stderr:\n%s\n" "$stderr"
+    fi
+  }
+
+  if [[ -n "$expected_rc" ]]; then
+    if [[ "$expected_rc" = "-1" ]]; then
+      if [[ "$status" -eq 0 ]]; then
+        BATS_ERROR_SUFFIX=", expected nonzero exit code!"
+        bats_run_print_output
+        return 1
+      fi
+    elif [ "$status" -ne "$expected_rc" ]; then
+      # shellcheck disable=SC2034
+      BATS_ERROR_SUFFIX=", expected exit code $expected_rc, got $status"
+      bats_run_print_output
+      return 1
+    fi
+  elif [[ "$status" -eq 127 ]]; then # "command not found"
+    bats_generate_warning 1 "$BATS_RUN_COMMAND"
+  fi
+
+  if [[ ${BATS_VERBOSE_RUN:-} ]]; then
+    bats_run_print_output
+  fi
+  
+  # don't leak our trap into surrounding code
+  trap bats_interrupt_trap INT
+}
+
+setup() {
+  return 0
+}
+
+teardown() {
+  return 0
+}
+
+skip() {
+  # if this is a skip in teardown ...
+  if [[ -n "${BATS_TEARDOWN_STARTED-}" ]]; then
+    # ... we want to skip the rest of teardown.
+    # communicate to bats_exit_trap that the teardown was completed without error
+    # shellcheck disable=SC2034
+    BATS_TEARDOWN_COMPLETED=1
+    # if we are already in the exit trap (e.g. due to previous skip) ...
+    if [[ "$BATS_TEARDOWN_STARTED" == as-exit-trap ]]; then
+      # ... we need to do the rest of the tear_down_trap that would otherwise be skipped after the next call to exit
+      bats_exit_trap
+      # and then do the exit (at the end of this function)
+    fi
+    # if we aren't in exit trap, the normal exit handling should suffice
+  else
+    # ... this is either skip in test or skip in setup.
+    # Following variables are used in bats-exec-test which sources this file
+    # shellcheck disable=SC2034
+    BATS_TEST_SKIPPED="${1:-1}"
+    # shellcheck disable=SC2034
+    BATS_TEST_COMPLETED=1
+  fi
+  exit 0
+}
+
+bats_test_function() {
+  local tags=()
+  while (( $# > 0 )); do
+    case "$1" in
+      --description)
+        local test_description=
+        # use eval to resolve variable references in test names
+        eval "printf -v test_description '%s' \"$2\""
+        shift 2
+      ;;
+      --tags)
+        IFS=',' read -ra tags <<<"$2"
+        shift 2
+      ;;
+      --)
+        shift
+        break
+      ;;
+      *)
+        printf "ERROR: unknown option %s for bats_test_function" "$1" >&2
+        exit 1
+      ;;
+    esac
+  done
+  BATS_TEST_NAMES+=("$*")
+  local quoted_parameters
+  printf -v quoted_parameters " %q" "$@"
+  quoted_parameters=${quoted_parameters:1} # cut off leading space
+
+  # if this is the currently selected test, set tags and name
+  # this should only be entered from bats-exec-test
+  if [[ ${BATS_TEST_NAME-} == "$quoted_parameters"  ]]; then
+    # shellcheck disable=SC2034
+    BATS_TEST_TAGS=("${tags[@]+${tags[@]}}")
+    export BATS_TEST_DESCRIPTION="${test_description-$*}"
+    # shellcheck disable=SC2034
+    BATS_TEST_COMMAND=("$@")    
+  fi
+}
+
+# decides whether a failed test should be run again
+bats_should_retry_test() {
+  # test try number starts at 1
+  # 0 retries means run only first try
+  ((BATS_TEST_TRY_NUMBER <= BATS_TEST_RETRIES))
+}

--- a/tests/vendor/bats-core/lib/bats-core/tracing.bash
+++ b/tests/vendor/bats-core/lib/bats-core/tracing.bash
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+
+# shellcheck source=lib/bats-core/common.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/common.bash"
+
+# set limit such that traces are only captured for calls at the same depth as this function in the calltree
+bats_set_stacktrace_limit() {
+  BATS_STACK_TRACE_LIMIT=$(( ${#FUNCNAME[@]} - 1 )) # adjust by -1 to account for call to this functions
+}
+
+bats_capture_stack_trace() {
+  local test_file
+  local funcname
+  local i
+
+  BATS_DEBUG_LAST_STACK_TRACE=()
+  local limit=$(( ${#FUNCNAME[@]} - ${BATS_STACK_TRACE_LIMIT-0} ))
+  # TODO: why is the line number off by one in  @test "--trace recurses into functions but not into run"
+  for ((i = 2; i < limit ; ++i)); do
+    # Use BATS_TEST_SOURCE if necessary to work around Bash < 4.4 bug whereby
+    # calling an exported function erases the test file's BASH_SOURCE entry.
+    test_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
+    funcname="${FUNCNAME[$i]}"
+    BATS_DEBUG_LAST_STACK_TRACE+=("${BASH_LINENO[$((i - 1))]} $funcname $test_file")
+  done
+}
+
+bats_get_failure_stack_trace() {
+  local stack_trace_var
+  # See bats_debug_trap for details.
+  if [[ -n "${BATS_DEBUG_LAST_STACK_TRACE_IS_VALID:-}" ]]; then
+    stack_trace_var=BATS_DEBUG_LAST_STACK_TRACE
+  else
+    stack_trace_var=BATS_DEBUG_LASTLAST_STACK_TRACE
+  fi
+  # shellcheck disable=SC2016
+  eval "$(printf \
+    '%s=(${%s[@]+"${%s[@]}"})' \
+    "${1}" \
+    "${stack_trace_var}" \
+    "${stack_trace_var}")"
+}
+
+bats_print_stack_trace() {
+  local frame
+  local index=1
+  local count="${#@}"
+  local filename
+  local lineno
+
+  for frame in "$@"; do
+    bats_frame_filename "$frame" 'filename'
+    bats_trim_filename "$filename" 'filename'
+    bats_frame_lineno "$frame" 'lineno'
+
+    printf '%s' "${BATS_STACK_TRACE_PREFIX-# }"
+    if [[ $index -eq 1 ]]; then
+      printf '('
+    else
+      printf ' '
+    fi
+
+    local fn
+    bats_frame_function "$frame" 'fn'
+    if [[ "$fn" != "${BATS_TEST_NAME-}" ]] &&
+      # don't print "from function `source'"",
+      # when failing in free code during `source $test_file` from bats-exec-file
+      ! [[ "$fn" == 'source' && $index -eq $count ]]; then
+      local quoted_fn
+      bats_quote_code quoted_fn "$fn"
+      printf "from function %s " "$quoted_fn"
+    fi
+
+    local reference
+    bats_format_file_line_reference reference "$filename" "$lineno"
+    if [[ $index -eq $count ]]; then
+      printf 'in test file %s)\n' "$reference"
+    else
+      printf 'in file %s,\n' "$reference"
+    fi
+
+    ((++index))
+  done
+}
+
+bats_print_failed_command() {
+  local stack_trace=("${@}")
+  if [[ ${#stack_trace[@]} -eq 0 ]]; then
+    return 0
+  fi
+  local frame="${stack_trace[${#stack_trace[@]} - 1]}"
+  local filename
+  local lineno
+  local failed_line
+  local failed_command
+
+  bats_frame_filename "$frame" 'filename'
+  bats_frame_lineno "$frame" 'lineno'
+  bats_extract_line "$filename" "$lineno" 'failed_line'
+  bats_strip_string "$failed_line" 'failed_command'
+  local quoted_failed_command
+  bats_quote_code quoted_failed_command "$failed_command"
+  printf '#   %s ' "${quoted_failed_command}"
+
+  if [[ "${BATS_TIMED_OUT-NOTSET}" != NOTSET ]]; then
+    # the other values can be safely overwritten here,
+    # as the timeout is the primary reason for failure
+    BATS_ERROR_SUFFIX=" due to timeout"
+  fi
+
+  if [[ "$BATS_ERROR_STATUS" -eq 1 ]]; then
+    printf 'failed%s\n' "$BATS_ERROR_SUFFIX"
+  else
+    printf 'failed with status %d%s\n' "$BATS_ERROR_STATUS" "$BATS_ERROR_SUFFIX"
+  fi
+}
+
+bats_frame_lineno() {
+  printf -v "$2" '%s' "${1%% *}"
+}
+
+bats_frame_function() {
+  local __bff_function="${1#* }"
+  printf -v "$2" '%s' "${__bff_function%% *}"
+}
+
+bats_frame_filename() {
+  local __bff_filename="${1#* }"
+  __bff_filename="${__bff_filename#* }"
+
+  if [[ "$__bff_filename" == "${BATS_TEST_SOURCE-}" ]]; then
+    __bff_filename="$BATS_TEST_FILENAME"
+  fi
+  printf -v "$2" '%s' "$__bff_filename"
+}
+
+bats_extract_line() {
+  local __bats_extract_line_line
+  local __bats_extract_line_index=0
+
+  while IFS= read -r __bats_extract_line_line; do
+    if [[ "$((++__bats_extract_line_index))" -eq "$2" ]]; then
+      printf -v "$3" '%s' "${__bats_extract_line_line%$'\r'}"
+      break
+    fi
+  done <"$1"
+}
+
+bats_strip_string() {
+  [[ "$1" =~ ^[[:space:]]*(.*)[[:space:]]*$ ]]
+  printf -v "$2" '%s' "${BASH_REMATCH[1]}"
+}
+
+bats_trim_filename() {
+  printf -v "$2" '%s' "${1#"$BATS_CWD"/}"
+}
+
+# normalize a windows path from e.g. C:/directory to /c/directory
+# The path must point to an existing/accessible directory, not a file!
+bats_normalize_windows_dir_path() { # <output-var> <path>
+  local output_var="$1" path="$2"
+  if [[ "$output_var" != NORMALIZED_INPUT ]]; then
+    local NORMALIZED_INPUT
+  fi
+  if [[ $path == ?:* ]]; then
+    NORMALIZED_INPUT="$(
+      cd "$path" || exit 1
+      pwd
+    )"
+  else
+    NORMALIZED_INPUT="$path"
+  fi
+  printf -v "$output_var" "%s" "$NORMALIZED_INPUT"
+}
+
+bats_emit_trace_context() {
+  local padding='$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$'
+  local reference
+  bats_format_file_line_reference reference "${file##*/}" "$line"
+  printf '%s [%s]\n' "${padding::${#BASH_LINENO[@]}-limit-3}" "$reference" >&4
+}
+
+bats_emit_trace_command() {
+  local padding='$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$'
+  printf '%s %s\n' "${padding::${#BASH_LINENO[@]}-limit-3}" "$BASH_COMMAND" >&4
+
+  # keep track of printed commands
+  BATS_LAST_BASH_COMMAND="$BASH_COMMAND"
+  BATS_LAST_BASH_LINENO="$line"
+}
+
+BATS_EMIT_TRACE_LAST_STACK_DIFF=0
+
+bats_emit_trace() {
+  if [[ ${BATS_TRACE_LEVEL:-0} -gt 0 ]]; then
+    local line=${BASH_LINENO[1]} limit=${BATS_STACK_TRACE_LIMIT-0}
+    # shellcheck disable=SC2016
+    if (( ${#FUNCNAME[@]} > limit + 2 ))  # only emit below BATS_STRACK_TRACE_LIMIT (adjust by 2 for trap+this function call)
+      # avoid printing the same line twice on errexit
+      [[ $BASH_COMMAND != "$BATS_LAST_BASH_COMMAND" || $line != "$BATS_LAST_BASH_LINENO" ]]; then
+      local file="${BASH_SOURCE[2]}" # index 2: skip over bats_emit_trace and bats_debug_trap
+      if [[ $file == "${BATS_TEST_SOURCE:-}" ]]; then
+        file="$BATS_TEST_FILENAME"
+      fi
+      # stack size difference since last call of this function
+      # <0: means new function call  
+      # >0: means return
+      # =0: in same function as before (assuming we did not skip return/call)
+      local stack_diff=$(( BATS_LAST_STACK_DEPTH - ${#BASH_LINENO[@]} ))
+      # show context immediately when returning or on second command in new function
+      # as the first "command" is the function itself
+      if (( stack_diff > 0 )) || (( BATS_EMIT_TRACE_LAST_STACK_DIFF < 0 )); then
+          bats_emit_trace_context
+      fi
+      # only print command when moving up or staying in same function
+      # again, avoids printing the first command (the function itself) in new function
+      if (( stack_diff >= 0 )); then
+        bats_emit_trace_command
+      fi
+
+      BATS_EMIT_TRACE_LAST_STACK_DIFF=$stack_diff
+    fi
+    # always update to detect stack depth changes regardless of printing
+    BATS_LAST_STACK_DEPTH="${#BASH_LINENO[@]}"
+  fi
+}
+
+# bats_debug_trap tracks the last line of code executed within a test. This is
+# necessary because $BASH_LINENO is often incorrect inside of ERR and EXIT
+# trap handlers.
+#
+# Below are tables describing different command failure scenarios and the
+# reliability of $BASH_LINENO within different the executed DEBUG, ERR, and EXIT
+# trap handlers. Naturally, the behaviors change between versions of Bash.
+#
+# Table rows should be read left to right. For example, on bash version
+# 4.0.44(2)-release, if a test executes `false` (or any other failing external
+# command), bash will do the following in order:
+# 1. Call the DEBUG trap handler (bats_debug_trap) with $BASH_LINENO referring
+#    to the source line containing the `false` command, then
+# 2. Call the DEBUG trap handler again, but with an incorrect $BASH_LINENO, then
+# 3. Call the ERR trap handler, but with a (possibly-different) incorrect
+#    $BASH_LINENO, then
+# 4. Call the DEBUG trap handler again, but with $BASH_LINENO set to 1, then
+# 5. Call the EXIT trap handler, with $BASH_LINENO set to 1.
+#
+# bash version 4.4.20(1)-release
+#  command     | first DEBUG | second DEBUG | ERR     | third DEBUG | EXIT
+# -------------+-------------+--------------+---------+-------------+--------
+#  false       | OK          | OK           | OK      | BAD[1]      | BAD[1]
+#  [[ 1 = 2 ]] | OK          | BAD[2]       | BAD[2]  | BAD[1]      | BAD[1]
+#  (( 1 = 2 )) | OK          | BAD[2]       | BAD[2]  | BAD[1]      | BAD[1]
+#  ! true      | OK          | ---          | BAD[4]  | ---         | BAD[1]
+#  $var_dne    | OK          | ---          | ---     | BAD[1]      | BAD[1]
+#  source /dne | OK          | ---          | ---     | BAD[1]      | BAD[1]
+#
+# bash version 4.0.44(2)-release
+#  command     | first DEBUG | second DEBUG | ERR     | third DEBUG | EXIT
+# -------------+-------------+--------------+---------+-------------+--------
+#  false       | OK          | BAD[3]       | BAD[3]  | BAD[1]      | BAD[1]
+#  [[ 1 = 2 ]] | OK          | ---          | BAD[3]  | ---         | BAD[1]
+#  (( 1 = 2 )) | OK          | ---          | BAD[3]  | ---         | BAD[1]
+#  ! true      | OK          | ---          | BAD[3]  | ---         | BAD[1]
+#  $var_dne    | OK          | ---          | ---     | BAD[1]      | BAD[1]
+#  source /dne | OK          | ---          | ---     | BAD[1]      | BAD[1]
+#
+# [1] The reported line number is always 1.
+# [2] The reported source location is that of the beginning of the function
+#     calling the command.
+# [3] The reported line is that of the last command executed in the DEBUG trap
+#     handler.
+# [4] The reported source location is that of the call to the function calling
+#     the command.
+bats_debug_trap() {
+  # on windows we sometimes get a mix of paths (when install via nmp install -g)
+  # which have C:/... or /c/... comparing them is going to be problematic.
+  # We need to normalize them to a common format!
+  local NORMALIZED_INPUT
+  bats_normalize_windows_dir_path NORMALIZED_INPUT "${1%/*}"
+  local file_excluded='' path
+  for path in "${BATS_DEBUG_EXCLUDE_PATHS[@]}"; do
+    if [[ "$NORMALIZED_INPUT" == "$path"* ]]; then
+      file_excluded=1
+      break
+    fi
+  done
+
+  # don't update the trace within library functions or we get backtraces from inside traps
+  # also don't record new stack traces while handling interruptions, to avoid overriding the interrupted command
+  if [[ -z "$file_excluded" &&
+    "${BATS_INTERRUPTED-NOTSET}" == NOTSET &&
+    "${BATS_TIMED_OUT-NOTSET}" == NOTSET ]]; then
+    BATS_DEBUG_LASTLAST_STACK_TRACE=(
+      ${BATS_DEBUG_LAST_STACK_TRACE[@]+"${BATS_DEBUG_LAST_STACK_TRACE[@]}"}
+    )
+
+    BATS_DEBUG_LAST_LINENO=(${BASH_LINENO[@]+"${BASH_LINENO[@]}"})
+    BATS_DEBUG_LAST_SOURCE=(${BASH_SOURCE[@]+"${BASH_SOURCE[@]}"})
+    bats_capture_stack_trace
+    bats_emit_trace
+  fi
+}
+
+# For some versions of Bash, the `ERR` trap may not always fire for every
+# command failure, but the `EXIT` trap will. Also, some command failures may not
+# set `$?` properly. See #72 and #81 for details.
+#
+# For this reason, we call `bats_check_status_from_trap` at the very beginning
+# of `bats_teardown_trap` and check the value of `$BATS_TEST_COMPLETED` before
+# taking other actions. We also adjust the exit status value if needed.
+#
+# See `bats_exit_trap` for an additional EXIT error handling case when `$?`
+# isn't set properly during `teardown()` errors.
+bats_check_status_from_trap() {
+  local status="$?"
+  if [[ -z "${BATS_TEST_COMPLETED:-}" ]]; then
+    BATS_ERROR_STATUS="${BATS_ERROR_STATUS:-$status}"
+    if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
+      BATS_ERROR_STATUS=1
+    fi
+    trap - DEBUG
+  fi
+}
+
+bats_add_debug_exclude_path() { # <path>
+  if [[ -z "$1" ]]; then        # don't exclude everything
+    printf "bats_add_debug_exclude_path: Exclude path must not be empty!\n" >&2
+    return 1
+  fi
+  if [[ "$OSTYPE" == cygwin || "$OSTYPE" == msys ]]; then
+    local normalized_dir
+    bats_normalize_windows_dir_path normalized_dir "$1"
+    BATS_DEBUG_EXCLUDE_PATHS+=("$normalized_dir")
+  else
+    BATS_DEBUG_EXCLUDE_PATHS+=("$1")
+  fi
+}
+
+bats_setup_tracing() {
+  # Variables for capturing accurate stack traces. See bats_debug_trap for
+  # details.
+  #
+  # BATS_DEBUG_LAST_LINENO, BATS_DEBUG_LAST_SOURCE, and
+  # BATS_DEBUG_LAST_STACK_TRACE hold data from the most recent call to
+  # bats_debug_trap.
+  #
+  # BATS_DEBUG_LASTLAST_STACK_TRACE holds data from two bats_debug_trap calls
+  # ago.
+  #
+  # BATS_DEBUG_LAST_STACK_TRACE_IS_VALID indicates that
+  # BATS_DEBUG_LAST_STACK_TRACE contains the stack trace of the test's error. If
+  # unset, BATS_DEBUG_LAST_STACK_TRACE is unreliable and
+  # BATS_DEBUG_LASTLAST_STACK_TRACE should be used instead.
+  BATS_DEBUG_LASTLAST_STACK_TRACE=()
+  BATS_DEBUG_LAST_LINENO=()
+  BATS_DEBUG_LAST_SOURCE=()
+  BATS_DEBUG_LAST_STACK_TRACE=()
+  BATS_DEBUG_LAST_STACK_TRACE_IS_VALID=
+  BATS_ERROR_SUFFIX=
+  BATS_DEBUG_EXCLUDE_PATHS=()
+  # exclude some paths by default
+  bats_add_debug_exclude_path "$BATS_ROOT/$BATS_LIBDIR/"
+  bats_add_debug_exclude_path "$BATS_ROOT/libexec/"
+
+  exec 4<&1 # used for tracing
+  if [[ "${BATS_TRACE_LEVEL:-0}" -gt 0 ]]; then
+    # avoid undefined variable errors
+    BATS_LAST_BASH_COMMAND=
+    BATS_LAST_BASH_LINENO=
+    BATS_LAST_STACK_DEPTH=
+    # try to exclude helper libraries if found, this is only relevant for tracing
+    while read -r path; do
+      bats_add_debug_exclude_path "$path"
+    done < <(find "$PWD" -type d -name bats-assert -o -name bats-support)
+  fi
+
+  local exclude_paths path
+  # exclude user defined libraries
+  IFS=':' read -r exclude_paths <<<"${BATS_DEBUG_EXCLUDE_PATHS:-}"
+  for path in "${exclude_paths[@]}"; do
+    if [[ -n "$path" ]]; then
+      bats_add_debug_exclude_path "$path"
+    fi
+  done
+
+  # turn on traps after setting excludes to avoid tracing the exclude setup
+  trap 'bats_debug_trap "$BASH_SOURCE"' DEBUG
+  trap 'bats_error_trap' ERR
+}
+
+bats_error_trap() {
+  bats_check_status_from_trap
+
+  # If necessary, undo the most recent stack trace captured by bats_debug_trap.
+  # See bats_debug_trap for details.
+  if [[ "${BASH_LINENO[*]}" = "${BATS_DEBUG_LAST_LINENO[*]:-}" &&
+    "${BASH_SOURCE[*]}" = "${BATS_DEBUG_LAST_SOURCE[*]:-}" &&
+    -z "$BATS_DEBUG_LAST_STACK_TRACE_IS_VALID" ]]; then
+    BATS_DEBUG_LAST_STACK_TRACE=(
+      ${BATS_DEBUG_LASTLAST_STACK_TRACE[@]+"${BATS_DEBUG_LASTLAST_STACK_TRACE[@]}"}
+    )
+  fi
+  BATS_DEBUG_LAST_STACK_TRACE_IS_VALID=1
+}
+
+bats_interrupt_trap() {
+  # mark the interruption, to handle during exit
+  BATS_INTERRUPTED=true
+  BATS_ERROR_STATUS=130
+  # debug trap fires before interrupt trap but gets wrong linenumber (line 1)
+  # -> use last stack trace instead of BATS_DEBUG_LAST_STACK_TRACE_IS_VALID=true
+}
+
+# this is used inside run()
+bats_interrupt_trap_in_run() {
+  # mark the interruption, to handle during exit
+  BATS_INTERRUPTED=true
+  BATS_ERROR_STATUS=130
+  BATS_DEBUG_LAST_STACK_TRACE_IS_VALID=true
+  exit 130
+}

--- a/tests/vendor/bats-core/lib/bats-core/validator.bash
+++ b/tests/vendor/bats-core/lib/bats-core/validator.bash
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+bats_test_count_validator() {
+  trap '' INT # continue forwarding
+  header_pattern='[0-9]+\.\.[0-9]+'
+  IFS= read -r header
+  # repeat the header
+  printf "%s\n" "$header"
+
+  # if we detect a TAP plan
+  if [[ "$header" =~ $header_pattern ]]; then
+    # extract the number of tests ...
+    local expected_number_of_tests="${header:3}"
+    # ... count the actual number of [not ] oks...
+    local actual_number_of_tests=0
+    while IFS= read -r line; do
+      # forward line
+      printf "%s\n" "$line"
+      case "$line" in
+      'ok '*)
+        ((++actual_number_of_tests))
+        ;;
+      'not ok'*)
+        ((++actual_number_of_tests))
+        ;;
+      esac
+    done
+    # ... and error if they are not the same
+    if [[ "${actual_number_of_tests}" != "${expected_number_of_tests}" ]]; then
+      printf '# bats warning: Executed %s instead of expected %s tests\n' "$actual_number_of_tests" "$expected_number_of_tests"
+      return 1
+    fi
+  else
+    # forward output unchanged
+    cat
+  fi
+}

--- a/tests/vendor/bats-core/lib/bats-core/warnings.bash
+++ b/tests/vendor/bats-core/lib/bats-core/warnings.bash
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# shellcheck source=lib/bats-core/tracing.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/tracing.bash"
+
+# generate a warning report for the parent call's call site
+bats_generate_warning() { # <warning number> [--no-stacktrace] [<printf args for warning string>...]
+  local warning_number="${1-}" padding="00"
+  shift
+  local no_stacktrace=
+  if [[ ${1-} == --no-stacktrace ]]; then
+    no_stacktrace=1
+    shift
+  fi
+  if [[ $warning_number =~ [0-9]+ ]] && ((warning_number < ${#BATS_WARNING_SHORT_DESCS[@]})); then
+    {
+      printf "BW%s: ${BATS_WARNING_SHORT_DESCS[$warning_number]}\n" "${padding:${#warning_number}}${warning_number}" "$@"
+      if [[ -z "$no_stacktrace" ]]; then
+        bats_capture_stack_trace
+        BATS_STACK_TRACE_PREFIX='      ' bats_print_stack_trace "${BATS_DEBUG_LAST_STACK_TRACE[@]}"
+      fi
+    } >>"$BATS_WARNING_FILE" 2>&3
+  else
+    printf "Invalid Bats warning number '%s'. It must be an integer between 1 and %d." "$warning_number" "$((${#BATS_WARNING_SHORT_DESCS[@]} - 1))" >&2
+    exit 1
+  fi
+}
+
+# generate a warning if the BATS_GUARANTEED_MINIMUM_VERSION is not high enough
+bats_warn_minimum_guaranteed_version() { # <feature> <minimum required version>
+  if bats_version_lt "$BATS_GUARANTEED_MINIMUM_VERSION" "$2"; then
+    bats_generate_warning 2 "$1" "$2" "$2"
+  fi
+}
+
+# put after functions to avoid line changes in tests when new ones get added
+BATS_WARNING_SHORT_DESCS=(
+  # to start with 1
+  'PADDING'
+  # see issue #578 for context
+  "\`run\`'s command \`%s\` exited with code 127, indicating 'Command not found'. Use run's return code checks, e.g. \`run -127\`, to fix this message."
+  "%s requires at least BATS_VERSION=%s. Use \`bats_require_minimum_version %s\` to fix this message."
+  "\`setup_suite\` is visible to test file '%s', but was not executed. It belongs into 'setup_suite.bash' to be picked up automatically."
+)

--- a/tests/vendor/bats-core/libexec/bats-core/bats
+++ b/tests/vendor/bats-core/libexec/bats-core/bats
@@ -1,0 +1,517 @@
+#!/usr/bin/env bash
+set -e
+
+export BATS_VERSION='1.11.0'
+VALID_FORMATTERS="pretty, junit, tap, tap13"
+
+version() {
+  printf 'Bats %s\n' "$BATS_VERSION"
+}
+
+abort() {
+  local print_usage=1
+  if [[ ${1:-} == --no-print-usage ]]; then
+    print_usage=
+    shift
+  fi
+  printf 'Error: %s\n' "$1" >&2
+  if [[ -n $print_usage ]]; then
+    usage >&2
+  fi
+  exit 1
+}
+
+usage() {
+  local cmd="${0##*/}"
+  local line
+
+  cat <<HELP_TEXT_HEADER
+Usage: ${cmd} [OPTIONS] <tests>
+       ${cmd} [-h | -v]
+
+HELP_TEXT_HEADER
+
+  cat <<'HELP_TEXT_BODY'
+  <tests> is the path to a Bats test file, or the path to a directory
+  containing Bats test files (ending with ".bats")
+
+  -c, --count               Count test cases without running any tests
+  --code-quote-style <style>
+                            A two character string of code quote delimiters
+                            or 'custom' which requires setting $BATS_BEGIN_CODE_QUOTE and
+                            $BATS_END_CODE_QUOTE. Can also be set via $BATS_CODE_QUOTE_STYLE
+  --line-reference-format   Controls how file/line references e.g. in stack traces are printed:
+                              - comma_line (default): a.bats, line 1
+                              - colon:  a.bats:1
+                              - uri: file:///tests/a.bats:1
+                              - custom: provide your own via defining bats_format_file_line_reference_custom
+                                        with parameters <filename> <line>, store via `printf -v "$output"`
+  -f, --filter <regex>      Only run tests that match the regular expression
+  --filter-status <status>  Only run tests with the given status in the last completed (no CTRL+C/SIGINT) run.
+                            Valid <status> values are:
+                              failed - runs tests that failed or were not present in the last run
+                              missed - runs tests that were not present in the last run
+  --filter-tags <comma-separated-tag-list>
+                            Only run tests that match all the tags in the list (&&).
+                            You can negate a tag via prepending '!'.
+                            Specifying this flag multiple times allows for logical or (||):
+                            `--filter-tags A,B --filter-tags A,!C` matches tags (A && B) || (A && !C)
+  -F, --formatter <type>    Switch between formatters: pretty (default),
+                              tap (default w/o term), tap13, junit, /<absolute path to formatter>
+  --gather-test-outputs-in <directory>
+                            Gather the output of failing *and* passing tests
+                            as files in directory (if existing, must be empty)
+  -h, --help                Display this help message
+  -j, --jobs <jobs>         Number of parallel jobs (requires GNU parallel or shenwei356/rush)
+  --parallel-binary-name    Name of parallel binary
+  --no-tempdir-cleanup      Preserve test output temporary directory
+  --no-parallelize-across-files
+                            Serialize test file execution instead of running
+                            them in parallel (requires --jobs >1)
+  --no-parallelize-within-files
+                            Serialize test execution within files instead of
+                            running them in parallel (requires --jobs >1)
+  --report-formatter <type> Switch between reporters (same options as --formatter)
+  -o, --output <dir>        Directory to write report files (must exist)
+  -p, --pretty              Shorthand for "--formatter pretty"
+  --print-output-on-failure Automatically print the value of `$output` on failed tests
+  -r, --recursive           Include tests in subdirectories
+  --show-output-of-passing-tests
+                            Print output of passing tests
+  -t, --tap                 Shorthand for "--formatter tap"
+  -T, --timing              Add timing information to tests
+  -x, --trace               Print test commands as they are executed (like `set -x`)
+  --verbose-run             Make `run` print `$output` by default
+  -v, --version             Display the version number
+
+  For more information, see https://github.com/bats-core/bats-core
+HELP_TEXT_BODY
+}
+
+expand_path() {
+  local path="${1%/}"
+  local dirname="${path%/*}"
+  if [[ -z "$dirname" ]]; then
+    dirname=/
+  fi
+  local result="$2"
+  local OLDPWD="$PWD"
+
+  if [[ "$dirname" == "$path" ]]; then
+    dirname="$PWD"
+  else
+    cd "$dirname"
+    dirname="$PWD"
+    cd "$OLDPWD"
+  fi
+  printf -v "$result" '%s/%s' "$dirname" "${path##*/}"
+}
+
+BATS_LIBEXEC="$(
+  cd "$(dirname "$(bats_readlinkf "${BASH_SOURCE[0]}")")"
+  pwd
+)"
+export BATS_LIBEXEC
+export BATS_CWD="$PWD"
+export BATS_TEST_FILTER=
+export PATH="$BATS_LIBEXEC:$PATH"
+export BATS_ROOT_PID=$$
+export BATS_TMPDIR="${TMPDIR:-/tmp}"
+BATS_TMPDIR=${BATS_TMPDIR%/} # chop off trailing / to avoid duplication
+export BATS_RUN_TMPDIR=
+export BATS_GUARANTEED_MINIMUM_VERSION=0.0.0
+export BATS_LIB_PATH=${BATS_LIB_PATH-/usr/lib/bats}
+BATS_REPORT_OUTPUT_DIR=${BATS_REPORT_OUTPUT_DIR-.}
+export BATS_LINE_REFERENCE_FORMAT=${BATS_LINE_REFERENCE_FORMAT-comma_line}
+
+if [[ ! -d "${BATS_TMPDIR}" ]]; then
+  printf "Error: BATS_TMPDIR (%s) does not exist or is not a directory" "${BATS_TMPDIR}" >&2
+  exit 1
+elif [[ ! -w "${BATS_TMPDIR}" ]]; then
+  printf "Error: BATS_TMPDIR (%s) is not writable" "${BATS_TMPDIR}" >&2
+  exit 1
+fi
+
+arguments=()
+
+# list of single char options that don't expect a value
+single_char_flags="hvcprtTx"
+
+# Unpack single-character options bundled together, e.g. -cr, -pr.
+for arg in "$@"; do
+  if [[ "$arg" =~ ^-[^-]. ]]; then
+    index=1
+    while option="${arg:$((index++)):1}"; do
+      if [[ -z "$option" ]]; then
+        break
+      fi
+      if [[ "$single_char_flags" != *$option* && -n "${arg:index}" ]]; then
+        printf "Error: -%s is not allowed within pack of flags.\n" "$option"
+        printf "       Please put it last (e.g. \`-rF junit\` instead of \`-Fr junit\`), or on its own (\`-r -F junit\`)!\n"
+        exit 1
+      fi
+      arguments+=("-$option")
+    done
+  else
+    arguments+=("$arg")
+  fi
+  shift
+done
+
+set -- "${arguments[@]}"
+arguments=()
+
+unset flags recursive formatter_flags
+flags=('--dummy-flag')           # add a dummy flag to prevent unset variable errors on empty array expansion in old bash versions
+formatter_flags=('--dummy-flag') # add a dummy flag to prevent unset variable errors on empty array expansion in old bash versions
+formatter=${BATS_FORMATTER:-'tap'}
+report_formatter=''
+recursive=
+setup_suite_file=''
+export BATS_TEMPDIR_CLEANUP=1
+if [[ -z "${CI:-}" && -t 0 && -t 1 ]] && command -v tput >/dev/null; then
+  formatter='pretty'
+fi
+
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+  -h | --help)
+    version
+    usage
+    exit 0
+    ;;
+  -v | --version)
+    version
+    exit 0
+    ;;
+  -c | --count)
+    flags+=('-c')
+    ;;
+  -f | --filter)
+    shift
+    flags+=('-f' "$1")
+    ;;
+  -F | --formatter)
+    shift
+    # allow cat formatter to see extended output but don't advertise to users
+    if [[ $1 =~ ^(pretty|junit|tap|tap13|cat|/.*)$ ]]; then
+      formatter="$1"
+    else
+      printf "Unknown formatter '%s', valid options are %s\n" "$1" "${VALID_FORMATTERS}"
+      exit 1
+    fi
+    ;;
+  --report-formatter)
+    shift
+    if [[ $1 =~ ^(cat|pretty|junit|tap|tap13|/.*)$ ]]; then
+      report_formatter="$1"
+    else
+      printf "Unknown report formatter '%s', valid options are %s\n" "$1" "${VALID_FORMATTERS}"
+      exit 1
+    fi
+    ;;
+  -o | --output)
+    shift
+    BATS_REPORT_OUTPUT_DIR="$1"
+    ;;
+  -p | --pretty)
+    formatter='pretty'
+    ;;
+  -j | --jobs)
+    shift
+    flags+=('-j' "$1")
+    ;;
+  --parallel-binary-name)
+    shift
+    flags+=('--parallel-binary-name' "$1")
+    ;;
+  -r | --recursive)
+    recursive=1
+    ;;
+  -t | --tap)
+    formatter='tap'
+    ;;
+  -T | --timing)
+    flags+=('-T')
+    formatter_flags+=('-T')
+    ;;
+  # this flag is now a no-op, as it is the parallel default
+  --parallel-preserve-environment) ;;
+
+  --no-parallelize-across-files)
+    flags+=("--no-parallelize-across-files")
+    ;;
+  --no-parallelize-within-files)
+    flags+=("--no-parallelize-within-files")
+    ;;
+  --no-tempdir-cleanup)
+    BATS_TEMPDIR_CLEANUP=''
+    ;;
+  --tempdir) # for internal test consumption only!
+    BATS_RUN_TMPDIR="$2"
+    shift
+    ;;
+  -x | --trace)
+    flags+=(--trace)
+    ;;
+  --print-output-on-failure)
+    flags+=(--print-output-on-failure)
+    ;;
+  --show-output-of-passing-tests)
+    flags+=(--show-output-of-passing-tests)
+    ;;
+  --verbose-run)
+    flags+=(--verbose-run)
+    ;;
+  --gather-test-outputs-in)
+    shift
+    output_dir="$1"
+    if [ -d "$output_dir" ]; then
+      if ! find "$output_dir" -mindepth 1 -exec false {} + 2>/dev/null; then
+        abort --no-print-usage "Directory '$output_dir' must be empty for --gather-test-outputs-in"
+      fi
+    elif ! mkdir "$output_dir" 2>/dev/null; then
+      abort --no-print-usage "Could not create '$output_dir' for --gather-test-outputs-in"
+    fi
+    flags+=(--gather-test-outputs-in "$output_dir")
+    ;;
+  --setup-suite-file)
+    shift
+    setup_suite_file="$1"
+    ;;
+  --code-quote-style)
+    shift
+    BATS_CODE_QUOTE_STYLE="$1"
+    ;;
+  --filter-status)
+    shift
+    flags+=('--filter-status' "$1")
+    ;;
+  --filter-tags)
+    shift
+    flags+=('--filter-tags' "$1")
+    ;;
+  --line-reference-format)
+    shift
+    BATS_LINE_REFERENCE_FORMAT=$1
+    ;;
+  -*)
+    abort "Bad command line option '$1'"
+    ;;
+  *)
+    arguments+=("$1")
+    ;;
+  esac
+  shift
+done
+
+if [[ ! $BATS_LINE_REFERENCE_FORMAT =~ (custom|comma_line|colon|uri) ]]; then
+  abort "Invalid BATS_LINE_REFERENCE_FORMAT '$BATS_LINE_REFERENCE_FORMAT' (e.g. via --line-reference-format)"
+fi
+
+if [[ -n "${BATS_RUN_TMPDIR:-}" ]]; then
+  if [[ -d "$BATS_RUN_TMPDIR" ]]; then
+    printf "Error: BATS_RUN_TMPDIR (%s) already exists\n" "$BATS_RUN_TMPDIR" >&2
+    printf "Reusing old run directories can lead to unexpected results ... aborting!\n" >&2
+    exit 1
+  elif ! mkdir -p "$BATS_RUN_TMPDIR"; then
+    printf "Error: Failed to create BATS_RUN_TMPDIR (%s)\n" "$BATS_RUN_TMPDIR" >&2
+    exit 1
+  fi
+elif ! BATS_RUN_TMPDIR=$(mktemp -d "${BATS_TMPDIR}/bats-run-XXXXXX"); then
+  printf "Error: Failed to create BATS_RUN_TMPDIR (%s) with mktemp\n" "${BATS_TMPDIR}/bats-run-XXXXXX" >&2
+  exit 1
+fi
+
+export BATS_WARNING_FILE="${BATS_RUN_TMPDIR}/warnings.log"
+
+bats_exit_trap() {
+  if [[ -s "$BATS_WARNING_FILE" ]]; then
+    local pre_cat='' post_cat=''
+    if [[ $formatter == pretty ]]; then
+      pre_cat=$'\x1B[31m'
+      post_cat=$'\x1B[0m'
+    fi
+    printf "\nThe following warnings were encountered during tests:\n%s" "$pre_cat"
+    cat "$BATS_WARNING_FILE"
+    printf "%s" "$post_cat"
+  fi >&2
+
+  if [[ -n "$BATS_TEMPDIR_CLEANUP" ]]; then
+    rm -rf "$BATS_RUN_TMPDIR"
+  else
+    printf "BATS_RUN_TMPDIR: %s\n" "$BATS_RUN_TMPDIR" >&2
+  fi
+}
+
+trap bats_exit_trap EXIT
+
+if [[ "$formatter" != "tap" ]]; then
+  flags+=('-x')
+fi
+
+if [[ -n "$report_formatter" && "$report_formatter" != "tap" ]]; then
+  flags+=('-x')
+fi
+
+if [[ "$formatter" == "junit" ]]; then
+  flags+=('-T')
+  formatter_flags+=('--base-path' "${arguments[0]}")
+fi
+if [[ "$report_formatter" == "junit" ]]; then
+  flags+=('-T')
+  report_formatter_flags+=('--base-path' "${arguments[0]}")
+fi
+
+if [[ "$formatter" == "pretty" ]]; then
+  formatter_flags+=('--base-path' "${arguments[0]}")
+fi
+
+# if we don't need to filter extended syntax, use the faster formatter
+if [[ "$formatter" == tap && -z "$report_formatter" ]]; then
+  formatter="cat"
+fi
+
+bats_check_formatter() { # <formatter-path>
+  local -r formatter="$1"
+  if [[ ! -f "$formatter" ]]; then
+    printf "ERROR: Formatter '%s' is not readable!\n" "$formatter"
+    exit 1
+  elif [[ ! -x "$formatter" ]]; then
+    printf "ERROR: Formatter '%s' is not executable!\n" "$formatter"
+    exit 1
+  fi
+}
+
+if [[ $formatter == /* ]]; then # absolute paths are direct references to formatters
+  bats_check_formatter "$formatter"
+  interpolated_formatter="$formatter"
+else
+  interpolated_formatter="bats-format-${formatter}"
+fi
+
+if [[ "${#arguments[@]}" -eq 0 ]]; then
+  abort 'Must specify at least one <test>'
+fi
+
+if [[ -n "$report_formatter" ]]; then
+  if [[ ! -w "${BATS_REPORT_OUTPUT_DIR}" ]]; then
+    abort "Output path ${BATS_REPORT_OUTPUT_DIR} is not writeable"
+  fi
+  # only set BATS_REPORT_FILENAME if none was given
+  if [[ -z "${BATS_REPORT_FILENAME:-}" ]]; then
+    case "$report_formatter" in
+    tap | tap13)
+      BATS_REPORT_FILENAME="report.tap"
+      ;;
+    junit)
+      BATS_REPORT_FILENAME="report.xml"
+      ;;
+    *)
+      BATS_REPORT_FILENAME="report.log"
+      ;;
+    esac
+  fi
+fi
+
+if [[ $report_formatter == /* ]]; then # absolute paths are direct references to formatters
+  bats_check_formatter "$report_formatter"
+  interpolated_report_formatter="${report_formatter}"
+else
+  interpolated_report_formatter="bats-format-${report_formatter}"
+fi
+
+if [[ "${BATS_CODE_QUOTE_STYLE-BATS_CODE_QUOTE_STYLE_UNSET}" == BATS_CODE_QUOTE_STYLE_UNSET ]]; then
+  BATS_CODE_QUOTE_STYLE="\`'"
+fi
+
+case "${BATS_CODE_QUOTE_STYLE}" in
+??)
+  BATS_BEGIN_CODE_QUOTE="${BATS_CODE_QUOTE_STYLE::1}"
+  BATS_END_CODE_QUOTE="${BATS_CODE_QUOTE_STYLE:1:1}"
+  export BATS_BEGIN_CODE_QUOTE BATS_END_CODE_QUOTE
+  ;;
+custom)
+  if [[ ${BATS_BEGIN_CODE_QUOTE-BATS_BEGIN_CODE_QUOTE_UNSET} == BATS_BEGIN_CODE_QUOTE_UNSET ||
+    ${BATS_END_CODE_QUOTE-BATS_BEGIN_CODE_QUOTE_UNSET} == BATS_BEGIN_CODE_QUOTE_UNSET ]]; then
+    printf "ERROR: BATS_CODE_QUOTE_STYLE=custom requires BATS_BEGIN_CODE_QUOTE and BATS_END_CODE_QUOTE to be set\n" >&2
+    exit 1
+  fi
+  ;;
+*)
+  printf "ERROR: Unknown BATS_CODE_QUOTE_STYLE: %s\n" "$BATS_CODE_QUOTE_STYLE" >&2
+  exit 1
+  ;;
+esac
+
+if [[ -n "$setup_suite_file" && ! -f "$setup_suite_file" ]]; then
+  abort "--setup-suite-file $setup_suite_file does not exist!"
+fi
+
+filenames=()
+for filename in "${arguments[@]}"; do
+  expand_path "$filename" 'filename'
+
+  if [[ -z "$setup_suite_file" ]]; then
+    if [[ -d "$filename" ]]; then
+      dirname="$filename"
+    else
+      dirname="${filename%/*}"
+    fi
+    potential_setup_suite_file="$dirname/setup_suite.bash"
+    if [[ -e "$potential_setup_suite_file" ]]; then
+      setup_suite_file="$potential_setup_suite_file"
+    fi
+  fi
+
+  if [[ -d "$filename" ]]; then
+    shopt -s nullglob
+    if [[ "$recursive" -eq 1 ]]; then
+      while IFS= read -r -d $'\0' file; do
+        filenames+=("$file")
+      done < <(find -L "$filename" -type f -name "*.${BATS_FILE_EXTENSION:-bats}" -print0 | sort -z)
+    else
+      for suite_filename in "$filename"/*."${BATS_FILE_EXTENSION:-bats}"; do
+        filenames+=("$suite_filename")
+      done
+    fi
+    shopt -u nullglob
+  else
+    filenames+=("$filename")
+  fi
+done
+
+if [[ -n "$setup_suite_file" ]]; then
+  flags+=("--setup-suite-file" "$setup_suite_file")
+fi
+
+# shellcheck source=lib/bats-core/validator.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/validator.bash"
+
+trap 'BATS_INTERRUPTED=true' INT # let the lower levels handle the interruption
+
+set -o pipefail execfail
+
+# pipe stdin into command and to stdout
+# pipe command stdout to file
+bats_tee() { # <output-file> <command...>
+  local output_file=$1 status=0
+  shift
+  exec 3<&1 # use FD3 to get around pipe
+  tee >(cat >&3) | "$@" >"$output_file" || status=$?
+  if (( status != 0 )); then
+    printf "ERROR: command \`%s\` failed with status %d\n" "$*" "$status" >&2
+  fi
+  return $status
+}
+
+if [[ -n "$report_formatter" ]]; then
+  exec bats-exec-suite "${flags[@]}" "${filenames[@]}" |
+    bats_tee "${BATS_REPORT_OUTPUT_DIR}/${BATS_REPORT_FILENAME}" "$interpolated_report_formatter" "${report_formatter_flags[@]}" |
+    bats_test_count_validator |
+    "$interpolated_formatter" "${formatter_flags[@]}"
+else
+  exec bats-exec-suite "${flags[@]}" "${filenames[@]}" |
+    bats_test_count_validator |
+    "$interpolated_formatter" "${formatter_flags[@]}"
+fi

--- a/tests/vendor/bats-core/libexec/bats-core/bats-exec-file
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-exec-file
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+set -eET
+
+flags=('--dummy-flag')
+num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
+extended_syntax=''
+BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
+declare -r BATS_RETRY_RETURN_CODE=126
+export BATS_TEST_RETRIES=0 # no retries by default
+
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+  -j)
+    shift
+    num_jobs="$1"
+    ;;
+  -T)
+    flags+=('-T')
+    ;;
+  -x)
+    flags+=('-x')
+    extended_syntax=1
+    ;;
+  --no-parallelize-within-files)
+    # use singular to allow for users to override in file
+    BATS_NO_PARALLELIZE_WITHIN_FILE=1
+    ;;
+  --dummy-flag) ;;
+
+  --trace)
+    flags+=('--trace')
+    ;;
+  --print-output-on-failure)
+    flags+=(--print-output-on-failure)
+    ;;
+  --show-output-of-passing-tests)
+    flags+=(--show-output-of-passing-tests)
+    ;;
+  --verbose-run)
+    flags+=(--verbose-run)
+    ;;
+  --gather-test-outputs-in)
+    shift
+    flags+=(--gather-test-outputs-in "$1")
+    ;;
+  *)
+    break
+    ;;
+  esac
+  shift
+done
+
+filename="$1"
+TESTS_FILE="$2"
+
+if [[ ! -f "$filename" ]]; then
+  printf 'Testfile "%s" not found\n' "$filename" >&2
+  exit 1
+fi
+
+export BATS_TEST_FILENAME="$filename"
+
+# shellcheck source=lib/bats-core/preprocessing.bash
+# shellcheck disable=SC2153
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/preprocessing.bash"
+
+bats_run_setup_file() {
+  # shellcheck source=lib/bats-core/tracing.bash
+  # shellcheck disable=SC2153
+  source "$BATS_ROOT/$BATS_LIBDIR/bats-core/tracing.bash"
+  # shellcheck source=lib/bats-core/test_functions.bash
+  # shellcheck disable=SC2153
+  source "$BATS_ROOT/$BATS_LIBDIR/bats-core/test_functions.bash"
+
+  _bats_test_functions_setup -1 # invalid TEST_NUMBER, as this is not a test
+
+  exec 3<&1
+
+  # these are defined only to avoid errors when referencing undefined variables down the line
+  # shellcheck disable=2034
+  BATS_TEST_NAME= # used in tracing.bash
+  # shellcheck disable=2034
+  BATS_TEST_COMPLETED= # used in tracing.bash
+
+  BATS_SOURCE_FILE_COMPLETED=
+  BATS_SETUP_FILE_COMPLETED=
+  BATS_TEARDOWN_FILE_COMPLETED=
+  # shellcheck disable=2034
+  BATS_ERROR_STATUS= # used in tracing.bash
+  touch "$BATS_OUT"
+  bats_setup_tracing
+  trap 'bats_file_teardown_trap' EXIT
+
+  local status=0
+  # get the setup_file/teardown_file functions for this file (if it has them)
+  # shellcheck disable=SC1090
+  source "$BATS_TEST_SOURCE"
+
+  BATS_SOURCE_FILE_COMPLETED=1
+
+  bats_set_stacktrace_limit
+  setup_file >>"$BATS_OUT" 2>&1
+
+  BATS_SETUP_FILE_COMPLETED=1
+}
+
+bats_run_teardown_file() {
+  local bats_teardown_file_status=0
+  # avoid running the therdown trap due to errors in teardown_file
+  trap 'bats_file_exit_trap' EXIT
+  
+  bats_set_stacktrace_limit
+
+  # rely on bats_error_trap to catch failures
+  teardown_file >>"$BATS_OUT" 2>&1 || bats_teardown_file_status=$?
+
+  if ((bats_teardown_file_status == 0)); then
+    BATS_TEARDOWN_FILE_COMPLETED=1
+  elif [[ -n "${BATS_SETUP_FILE_COMPLETED:-}" ]]; then
+    BATS_DEBUG_LAST_STACK_TRACE_IS_VALID=1
+    BATS_ERROR_STATUS=$bats_teardown_file_status
+    return $BATS_ERROR_STATUS
+  fi
+}
+
+# shellcheck disable=SC2317
+bats_file_teardown_trap() {
+  bats_run_teardown_file
+  bats_file_exit_trap in-teardown_trap
+}
+
+# shellcheck source=lib/bats-core/common.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/common.bash"
+
+# shellcheck disable=SC2317
+bats_file_exit_trap() {
+  local -r last_return_code=$?
+  if [[ ${1:-} != in-teardown_trap ]]; then
+    BATS_ERROR_STATUS=$last_return_code
+  fi
+  trap - ERR EXIT
+  local failure_reason
+  local -i failure_test_index=$((BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE + 1))
+  if [[ -n "${BATS_TEST_SKIPPED-}" ]]; then
+    export BATS_TEST_SKIPPED # indicate to exec-test that it should skip
+    # print skip message for each test (use this to avoid reimplementing filtering)
+    bats_run_tests 1<&3 # restore original stdout (this is running in setup_file's redirection to BATS_OUT)
+    bats_exec_file_status=0 # this should not lead to errors
+  elif [[ -z "$BATS_SETUP_FILE_COMPLETED" || -z "$BATS_TEARDOWN_FILE_COMPLETED" ]]; then
+    if [[ -z "$BATS_SETUP_FILE_COMPLETED" ]]; then
+      failure_reason='setup_file'
+    elif [[ -z "$BATS_TEARDOWN_FILE_COMPLETED" ]]; then
+      failure_reason='teardown_file'
+      failure_test_index=$((BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE + ${#tests_to_run[@]} + 1))
+    elif [[ -z "$BATS_SOURCE_FILE_COMPLETED" ]]; then
+      failure_reason='source'
+    else
+      failure_reason='unknown internal'
+    fi
+    printf "not ok %d %s\n" "$failure_test_index" "$failure_reason failed" >&3
+    local stack_trace
+    bats_get_failure_stack_trace stack_trace
+    bats_print_stack_trace "${stack_trace[@]}" >&3
+    bats_print_failed_command "${stack_trace[@]}" >&3
+    bats_prefix_lines_for_tap_output <"$BATS_OUT" | bats_replace_filename >&3
+    rm -rf "$BATS_OUT"
+    bats_exec_file_status=1
+  fi
+
+  # setup_file not executed but defined in this test file? -> might be defined in the wrong file
+  if [[ -z "${BATS_SETUP_SUITE_COMPLETED-}" ]] && declare -F setup_suite >/dev/null; then
+    bats_generate_warning 3 --no-stacktrace "$BATS_TEST_FILENAME"
+  fi
+
+  exit "$bats_exec_file_status"
+}
+
+function setup_file() {
+  return 0
+}
+
+function teardown_file() {
+  return 0
+}
+
+bats_forward_output_of_parallel_test() {
+  local test_number_in_suite=$1
+  local status=0
+  wait "$(cat "$output_folder/$test_number_in_suite/pid")" || status=1
+  cat "$output_folder/$test_number_in_suite/stdout"
+  cat "$output_folder/$test_number_in_suite/stderr" >&2
+  return $status
+}
+
+bats_is_next_parallel_test_finished() {
+  local PID
+  # get the pid of the next potentially finished test
+  PID=$(cat "$output_folder/$((test_number_in_suite_of_last_finished_test + 1))/pid")
+  # try to send a signal to this process
+  # if it fails, the process exited,
+  # if it succeeds, the process is still running
+  if kill -0 "$PID" 2>/dev/null; then
+    return 1
+  fi
+}
+
+# prints output from all tests in the order they were started
+# $1 == "blocking": wait for a test to finish before printing
+#    != "blocking": abort printing, when a test has not finished
+bats_forward_output_for_parallel_tests() {
+  local status=0
+  # was the next test already started?
+  while ((test_number_in_suite_of_last_finished_test + 1 <= test_number_in_suite)); do
+    # if we are okay with waiting or if the test has already been finished
+    if [[ "$1" == "blocking" ]] || bats_is_next_parallel_test_finished; then
+      ((++test_number_in_suite_of_last_finished_test))
+      bats_forward_output_of_parallel_test "$test_number_in_suite_of_last_finished_test" || status=$?
+    else
+      # non-blocking and the process has not finished -> abort the printing
+      break
+    fi
+  done
+  return $status
+}
+
+bats_run_test_with_retries() { # <args>
+  local status=0
+  local should_try_again=1 try_number
+  for ((try_number = 1; should_try_again; ++try_number)); do
+    if "$BATS_LIBEXEC/bats-exec-test" "$@" "$try_number"; then
+      should_try_again=0
+    else
+      status=$?
+      if ((status == BATS_RETRY_RETURN_CODE)); then
+        should_try_again=1
+        status=0 # this is not the last try -> reset status
+      else
+        should_try_again=0
+        bats_exec_file_status=$status
+      fi
+    fi
+  done
+  return $status
+}
+
+bats_run_tests_in_parallel() {
+  local output_folder="$BATS_RUN_TMPDIR/parallel_output"
+  local status=0
+  mkdir -p "$output_folder"
+  # shellcheck source=lib/bats-core/semaphore.bash
+  source "$BATS_ROOT/$BATS_LIBDIR/bats-core/semaphore.bash"
+  bats_semaphore_setup
+  # the test_number_in_file is not yet incremented -> one before the next test to run
+  local test_number_in_suite_of_last_finished_test="$BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE" # stores which test was printed last
+  local test_number_in_file=0 test_number_in_suite=$BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE
+  for test_name in "${tests_to_run[@]}"; do
+    # Only handle non-empty lines
+    if [[ $test_name ]]; then
+      ((++test_number_in_suite))
+      ((++test_number_in_file))
+      mkdir -p "$output_folder/$test_number_in_suite"
+      bats_semaphore_run "$output_folder/$test_number_in_suite" \
+        bats_run_test_with_retries "${flags[@]}" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" \
+        >"$output_folder/$test_number_in_suite/pid"
+    fi
+    # print results early to get interactive feedback
+    bats_forward_output_for_parallel_tests non-blocking || status=1 # ignore if we did not finish yet
+  done
+  bats_forward_output_for_parallel_tests blocking || status=1
+  return $status
+}
+
+bats_read_tests_list_file() {
+  local line_number=0
+  tests_to_run=()
+  # the global test number must be visible to traps -> not local
+  local test_number_in_suite=''
+  while read -r test_line; do
+    # check if the line begins with filename
+    # filename might contain some hard to parse characters,
+    # use simple string operations to work around that issue
+    if [[ "$filename" == "${test_line::${#filename}}" ]]; then
+      # get the rest of the line without the separator \t
+      test_name=${test_line:$((1 + ${#filename}))}
+      tests_to_run+=("$test_name")
+      # save the first test's number for later iteration
+      # this assumes that tests for a file are stored consecutive in the file!
+      if [[ -z "$test_number_in_suite" ]]; then
+        test_number_in_suite=$line_number
+      fi
+    fi
+    ((++line_number))
+  done <"$TESTS_FILE"
+  BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE="$test_number_in_suite"
+  declare -ri BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE # mark readonly (cannot merge assignment, because value would be lost)
+}
+
+bats_run_tests() {
+  bats_exec_file_status=0
+  # TODO: this does not seem to be used anymore?
+  if [[ "${BATS_RUN_TESTS_SKIPPED-}" ]]; then
+    # shellcheck disable=SC2317
+    bats_test_begin() {
+      printf "ok %d %s # skip %s\n" "$test_number_in_suite" "$1" "$BATS_RUN_TESTS_SKIPPED_REASON"  >&3
+      return 1
+    }
+    local test_number_in_suite=0
+    for test_name in "${tests_to_run[@]}"; do
+      ((++test_number_in_suite))
+      eval "$test_name" || true
+    done
+    exit 0
+  fi
+
+  if [[ "$num_jobs" -lt 1 ]]; then
+    printf 'Invalid number of jobs: %s\n' "$num_jobs" >&2
+    exit 1
+  fi
+
+  if [[ "$num_jobs" != 1 && "${BATS_NO_PARALLELIZE_WITHIN_FILE-False}" == False ]]; then
+    export BATS_SEMAPHORE_NUMBER_OF_SLOTS="$num_jobs"
+    bats_run_tests_in_parallel "$BATS_RUN_TMPDIR/parallel_output" || bats_exec_file_status=1
+  else
+    local test_number_in_suite=$BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE \
+      test_number_in_file=0
+    for test_name in "${tests_to_run[@]}"; do
+      #echo "bats-exec-file: execute test ${test_name}" >&2
+      if [[ "${BATS_INTERRUPTED-NOTSET}" != NOTSET ]]; then
+        bats_exec_file_status=130 # bash's code for SIGINT exits
+        break
+      fi
+      # Only handle non-empty lines
+      if [[ -n ${test_name-} ]]; then
+        ((++test_number_in_suite))
+        ((++test_number_in_file))
+        bats_run_test_with_retries "${flags[@]}" "$filename" "$test_name" \
+          "$test_number_in_suite" "$test_number_in_file" || bats_exec_file_status=$?
+      fi
+    done
+  fi
+}
+
+bats_create_file_tempdirs() {
+  local bats_files_tmpdir="${BATS_RUN_TMPDIR}/file"
+  if ! mkdir -p "$bats_files_tmpdir"; then
+    printf 'Failed to create %s\n' "$bats_files_tmpdir" >&2
+    exit 1
+  fi
+  BATS_FILE_TMPDIR="$bats_files_tmpdir/${BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE?}"
+  if ! mkdir "$BATS_FILE_TMPDIR"; then
+    printf 'Failed to create BATS_FILE_TMPDIR=%s\n' "$BATS_FILE_TMPDIR" >&2
+    exit 1
+  fi
+  ln -s "$BATS_TEST_FILENAME" "$BATS_FILE_TMPDIR-$(basename "$BATS_TEST_FILENAME").source_file"
+  export BATS_FILE_TMPDIR
+}
+
+trap 'BATS_INTERRUPTED=true' INT
+
+BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE=0 # predeclare as Bash 3.2 does not support declare -g
+bats_read_tests_list_file
+
+# don't run potentially expensive setup/teardown_file
+# when there are no tests to run
+if [[ ${#tests_to_run[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ -n "$extended_syntax" ]]; then
+  printf "suite %s\n" "$filename"
+fi
+
+# requires the test list to be read but not empty
+bats_create_file_tempdirs
+
+bats_preprocess_source "$filename"
+
+trap bats_interrupt_trap INT
+bats_run_setup_file
+
+# during tests, we don't want to get backtraces from this level
+# just wait for the test to be interrupted and display their trace
+trap 'BATS_INTERRUPTED=true' INT
+bats_run_tests
+
+trap bats_interrupt_trap INT
+bats_run_teardown_file
+
+exit $bats_exec_file_status

--- a/tests/vendor/bats-core/libexec/bats-core/bats-exec-suite
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-exec-suite
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+set -e
+
+count_only_flag=''
+filter=''
+num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
+parallel_binary_name=${BATS_PARALLEL_BINARY_NAME:-"parallel"}
+bats_no_parallelize_across_files=${BATS_NO_PARALLELIZE_ACROSS_FILES-}
+bats_no_parallelize_within_files=
+filter_status=''
+gather_tests_flags=('--dummy-flag')
+flags=('--dummy-flag') # add a dummy flag to prevent unset variable errors on empty array expansion in old bash versions
+setup_suite_file=''
+BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
+BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS=
+
+abort() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+# shellcheck source=lib/bats-core/common.bash disable=SC2153
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/common.bash"
+
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+  -c)
+    count_only_flag=1
+    ;;
+  -f)
+    shift
+    filter="$1"
+    ;;
+  -j)
+    shift
+    num_jobs="$1"
+    flags+=('-j' "$num_jobs")
+    ;;
+  --parallel-binary-name)
+    shift
+    parallel_binary_name="$1"
+    ;;
+  -T)
+    flags+=('-T')
+    ;;
+  -x)
+    flags+=('-x')
+    ;;
+  --no-parallelize-across-files)
+    bats_no_parallelize_across_files=1
+    ;;
+  --no-parallelize-within-files)
+    bats_no_parallelize_within_files=1
+    flags+=("--no-parallelize-within-files")
+    ;;
+  --filter-status)
+    shift
+    filter_status="$1"
+    ;;
+  --filter-tags)
+    shift
+    gather_tests_flags+=("--filter-tags" "$1")
+    ;;
+  --dummy-flag) ;;
+
+  --trace)
+    flags+=('--trace')
+    ((++BATS_TRACE_LEVEL)) # avoid returning 0
+    ;;
+  --print-output-on-failure)
+    flags+=(--print-output-on-failure)
+    ;;
+  --show-output-of-passing-tests)
+    flags+=(--show-output-of-passing-tests)
+    BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS=1
+    ;;
+  --verbose-run)
+    flags+=(--verbose-run)
+    ;;
+  --gather-test-outputs-in)
+    shift
+    flags+=(--gather-test-outputs-in "$1")
+    ;;
+  --setup-suite-file)
+    shift
+    setup_suite_file="$1"
+    ;;
+  *)
+    break
+    ;;
+  esac
+  shift
+done
+
+if [[ "$num_jobs" != 1 ]]; then
+  if ! type -p "${parallel_binary_name}" >/dev/null && "${parallel_binary_name}" --version &>/dev/null && [[ -z "$bats_no_parallelize_across_files" ]]; then
+    abort "Cannot execute \"${num_jobs}\" jobs without GNU parallel"
+  fi
+  # shellcheck source=lib/bats-core/semaphore.bash
+  source "${BATS_ROOT}/$BATS_LIBDIR/bats-core/semaphore.bash"
+  bats_semaphore_setup
+fi
+
+# create a file that contains all (filtered) tests to run from all files
+TESTS_LIST_FILE="${BATS_RUN_TMPDIR}/test_list_file.txt"
+
+TEST_ROOT=${1-}
+TEST_ROOT=${TEST_ROOT%/*}
+export BATS_RUN_LOGS_DIRECTORY="$TEST_ROOT/.bats/run-logs"
+if [[ ! -d "$BATS_RUN_LOGS_DIRECTORY" ]]; then
+  if [[ -n "$filter_status" ]]; then
+    printf "Error: --filter-status needs '%s/' to save failed tests. Please create this folder, add it to .gitignore and try again.\n" "$BATS_RUN_LOGS_DIRECTORY"
+    exit 1
+  else
+    BATS_RUN_LOGS_DIRECTORY=
+  fi
+  # discard via sink instead of having a conditional later
+  export BATS_RUNLOG_FILE='/dev/null'
+else
+  # use UTC (-u) to avoid problems with TZ changes
+  BATS_RUNLOG_DATE=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+  export BATS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/${BATS_RUNLOG_DATE}.log" BATS_RUNLOG_DATE
+  if [[ ! -w "$BATS_RUN_LOGS_DIRECTORY" ]]; then
+    printf "WARNING: Cannot write in %s. This run will not write a log!\n" "$BATS_RUN_LOGS_DIRECTORY" >&2
+    BATS_RUNLOG_FILE='/dev/null' # disable runlog file
+  fi
+fi
+
+# create file even if no tests are found so the `read` below won't fail
+touch "$TESTS_LIST_FILE"
+gather_tests_output=$(TESTS_LIST_FILE="$TESTS_LIST_FILE" filter="$filter" filter_status="$filter_status" bats-gather-tests "${gather_tests_flags[@]}" -- "$@")
+test_count=$(grep -c '' "$TESTS_LIST_FILE" || true) # don't fail here when there are no tests
+if [[ $gather_tests_output == focus_mode ]]; then
+  focus_mode=1
+else
+  focus_mode=
+fi
+
+if [[ -n "$count_only_flag" ]]; then
+  printf '%d\n' "${test_count}"
+  # we don't want to pollute the runlog files, as no tests would have been run
+  [[ $BATS_RUNLOG_FILE != /dev/null ]] && rm "$BATS_RUNLOG_FILE"
+  exit 0
+fi
+
+if [[ -n "$bats_no_parallelize_across_files" ]] && [[ ! "$num_jobs" -gt 1 ]]; then
+  abort "The flag --no-parallelize-across-files requires at least --jobs 2"
+fi
+
+if [[ -n "$bats_no_parallelize_within_files" ]] && [[ ! "$num_jobs" -gt 1 ]]; then
+  abort "The flag --no-parallelize-across-files requires at least --jobs 2"
+fi
+
+# only abort on the lowest levels
+trap 'BATS_INTERRUPTED=true' INT
+
+if [[ -n "$focus_mode" ]]; then
+  printf "WARNING: This test run only contains tests tagged \`bats:focus\`!\n"
+fi
+
+bats_exec_suite_status=0
+printf '1..%d\n' "${test_count}"
+
+# No point on continuing if there's no tests.
+if [[ "${test_count}" == 0 ]]; then
+  exit
+fi
+
+export BATS_SUITE_TMPDIR="${BATS_RUN_TMPDIR}/suite"
+if ! mkdir "$BATS_SUITE_TMPDIR"; then
+  printf '%s\n' "Failed to create BATS_SUITE_TMPDIR" >&2
+  exit 1
+fi
+
+# Deduplicate filenames (without reordering) to avoid running duplicate tests n by n times.
+# (see https://github.com/bats-core/bats-core/issues/329)
+# If a file was specified multiple times, we already got it repeatedly in our TESTS_LIST_FILE.
+# Thus, it suffices to bats-exec-file it once to run all repeated tests on it.
+IFS=$'\n' read -d '' -r -a BATS_UNIQUE_TEST_FILENAMES < <(printf "%s\n" "$@" | nl | sort -k 2 | uniq -f 1 | sort -n | cut -f 2-) || true
+
+# shellcheck source=lib/bats-core/tracing.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/tracing.bash"
+bats_setup_tracing
+
+trap bats_suite_exit_trap EXIT
+
+exec 3<&1
+
+# shellcheck disable=SC2317
+bats_suite_exit_trap() {
+  local print_bats_out="${BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS}"
+  if [[ -z "${BATS_SETUP_SUITE_COMPLETED}" || -z "${BATS_TEARDOWN_SUITE_COMPLETED}" ]]; then
+    if [[ -z "${BATS_SETUP_SUITE_COMPLETED}" ]]; then
+      printf "not ok 1 setup_suite\n"
+    elif [[ -z "${BATS_TEARDOWN_SUITE_COMPLETED}" ]]; then
+      printf "not ok %d teardown_suite\n" $((test_count + 1))
+    fi
+    local stack_trace
+    bats_get_failure_stack_trace stack_trace
+    bats_print_stack_trace "${stack_trace[@]}"
+    bats_print_failed_command "${stack_trace[@]}"
+    print_bats_out=1
+    bats_exec_suite_status=1
+  fi
+
+  if [[ -n "$print_bats_out" ]]; then
+    bats_prefix_lines_for_tap_output <"$BATS_OUT"
+  fi
+
+  if [[ ${BATS_INTERRUPTED-NOTSET} != NOTSET ]]; then
+    printf "\n# Received SIGINT, aborting ...\n\n"
+  fi
+
+  if [[ -d "$BATS_RUN_LOGS_DIRECTORY" && -n "${BATS_INTERRUPTED:-}" ]]; then
+    # aborting a test run with CTRL+C does not save the runlog file
+    [[ "$BATS_RUNLOG_FILE" != /dev/null ]] && rm "$BATS_RUNLOG_FILE"
+  fi
+  exit "$bats_exec_suite_status"
+} >&3
+
+bats_run_teardown_suite() {
+  local bats_teardown_suite_status=0
+  # avoid being called twice, in case this is not called through bats_teardown_suite_trap
+  # but from the end of file
+  trap bats_suite_exit_trap EXIT
+  
+  bats_set_stacktrace_limit
+
+  BATS_TEARDOWN_SUITE_COMPLETED=
+  teardown_suite >>"$BATS_OUT" 2>&1 || bats_teardown_suite_status=$?
+  if ((bats_teardown_suite_status == 0)); then
+    BATS_TEARDOWN_SUITE_COMPLETED=1
+  elif [[ -n "${BATS_SETUP_SUITE_COMPLETED:-}" ]]; then
+    BATS_DEBUG_LAST_STACK_TRACE_IS_VALID=1
+    BATS_ERROR_STATUS=$bats_teardown_suite_status
+    return $BATS_ERROR_STATUS
+  fi
+}
+
+# shellcheck disable=SC2317
+bats_teardown_suite_trap() {
+  bats_run_teardown_suite
+  bats_suite_exit_trap
+}
+
+teardown_suite() {
+  :
+}
+
+trap bats_teardown_suite_trap EXIT
+
+BATS_OUT="$BATS_RUN_TMPDIR/suite.out"
+if [[ -n "$setup_suite_file" ]]; then
+  setup_suite() {
+    printf "%s does not define \`setup_suite()\`\n" "$setup_suite_file" >&2
+    return 1
+  }
+
+  # shellcheck disable=SC2034 # will be used in the sourced file below
+  BATS_TEST_FILENAME="$setup_suite_file"
+  # shellcheck source=lib/bats-core/test_functions.bash
+  source "$BATS_ROOT/$BATS_LIBDIR/bats-core/test_functions.bash"
+  _bats_test_functions_setup -1 # invalid TEST_NUMBER, as this is not a test
+
+  # shellcheck disable=SC1090
+  source "$setup_suite_file"
+
+  bats_set_stacktrace_limit
+
+  set -eET
+  export BATS_SETUP_SUITE_COMPLETED=
+  setup_suite >>"$BATS_OUT" 2>&1
+  BATS_SETUP_SUITE_COMPLETED=1
+  set +ET
+else
+  # prevent exit trap from printing an error because of incomplete setup_suite,
+  # when there was none to execute
+  BATS_SETUP_SUITE_COMPLETED=1
+fi
+
+if [[ "$num_jobs" -gt 1 ]] && [[ -z "$bats_no_parallelize_across_files" ]]; then
+  # run files in parallel to get the maximum pool of parallel tasks
+  # shellcheck disable=SC2086,SC2068
+  # we need to handle the quoting of ${flags[@]} ourselves,
+  # because parallel can only quote it as one
+  "${parallel_binary_name}" --keep-order --jobs "$num_jobs" -- "bats-exec-file" "$(printf "%q " "${flags[@]}")" "{}" "$TESTS_LIST_FILE" <<< "$(printf "%s\n" "${BATS_UNIQUE_TEST_FILENAMES[@]}")" 2>&1 || bats_exec_suite_status=1
+else
+  for filename in "${BATS_UNIQUE_TEST_FILENAMES[@]}"; do
+    if [[ "${BATS_INTERRUPTED-NOTSET}" != NOTSET ]]; then
+      bats_exec_suite_status=130 # bash's code for SIGINT exits
+      break
+    fi
+    bats-exec-file "${flags[@]}" "$filename" "${TESTS_LIST_FILE}" || bats_exec_suite_status=1
+  done
+fi
+
+set -eET
+bats_run_teardown_suite
+
+if [[ "$focus_mode" == 1 && $bats_exec_suite_status -eq 0 ]]; then
+  if [[ ${BATS_NO_FAIL_FOCUS_RUN-} == 1 ]]; then
+    printf "WARNING: This test run only contains tests tagged \`bats:focus\`!\n"
+  else
+    printf "Marking test run as failed due to \`bats:focus\` tag. (Set \`BATS_NO_FAIL_FOCUS_RUN=1\` to disable.)\n" >&2
+    bats_exec_suite_status=1
+  fi
+fi
+
+exit "$bats_exec_suite_status" # the actual exit code will be set by the exit trap using bats_exec_suite_status

--- a/tests/vendor/bats-core/libexec/bats-core/bats-exec-test
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-exec-test
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+set -eET
+
+# Variables used in other scripts.
+BATS_ENABLE_TIMING=''
+BATS_EXTENDED_SYNTAX=''
+BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
+BATS_PRINT_OUTPUT_ON_FAILURE="${BATS_PRINT_OUTPUT_ON_FAILURE:-}"
+BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS="${BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS:-}"
+BATS_VERBOSE_RUN="${BATS_VERBOSE_RUN:-}"
+BATS_GATHER_TEST_OUTPUTS_IN="${BATS_GATHER_TEST_OUTPUTS_IN:-}"
+BATS_TEST_NAME_PREFIX="${BATS_TEST_NAME_PREFIX:-}"
+
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+  -T)
+    BATS_ENABLE_TIMING='-T'
+    ;;
+  -x)
+    # shellcheck disable=SC2034
+    BATS_EXTENDED_SYNTAX='-x'
+    ;;
+  --dummy-flag) ;;
+
+  --trace)
+    ((++BATS_TRACE_LEVEL)) # avoid returning 0
+    ;;
+  --print-output-on-failure)
+    BATS_PRINT_OUTPUT_ON_FAILURE=1
+    ;;
+  --show-output-of-passing-tests)
+    BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS=1
+    ;;
+  --verbose-run)
+    BATS_VERBOSE_RUN=1
+    ;;
+  --gather-test-outputs-in)
+    shift
+    BATS_GATHER_TEST_OUTPUTS_IN="$1"
+    ;;
+  *)
+    break
+    ;;
+  esac
+  shift
+done
+
+export BATS_TEST_FILENAME="$1"
+export BATS_TEST_NAME="$2"
+export BATS_SUITE_TEST_NUMBER="$3"
+export BATS_TEST_NUMBER="$4"
+BATS_TEST_TRY_NUMBER="$5"
+
+if [[ -z "$BATS_TEST_FILENAME" ]]; then
+  printf 'usage: bats-exec-test <filename>\n' >&2
+  exit 1
+elif [[ ! -f "$BATS_TEST_FILENAME" ]]; then
+  printf 'bats: %s does not exist\n' "$BATS_TEST_FILENAME" >&2
+  exit 1
+fi
+
+bats_create_test_tmpdirs() {
+  local tests_tmpdir="${BATS_RUN_TMPDIR}/test"
+  if ! mkdir -p "$tests_tmpdir"; then
+    printf 'Failed to create: %s\n' "$tests_tmpdir" >&2
+    exit 1
+  fi
+
+  BATS_TEST_TMPDIR="$tests_tmpdir/$BATS_SUITE_TEST_NUMBER"
+  if ! mkdir "$BATS_TEST_TMPDIR"; then
+    printf 'Failed to create BATS_TEST_TMPDIR%d: %s\n' "$BATS_TEST_TRY_NUMBER" "$BATS_TEST_TMPDIR" >&2
+    exit 1
+  fi
+
+  printf "%s\n" "$BATS_TEST_NAME" >"$BATS_TEST_TMPDIR.name"
+
+  export BATS_TEST_TMPDIR
+}
+
+# load the test helper functions like `load` or `run` that are needed to run a (preprocessed) .bats file without bash errors
+# shellcheck source=lib/bats-core/test_functions.bash disable=SC2153
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/test_functions.bash"
+_bats_test_functions_setup "$BATS_TEST_NUMBER"
+
+# shellcheck source=lib/bats-core/tracing.bash disable=SC2153
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/tracing.bash"
+
+bats_teardown_trap() {
+  bats_check_status_from_trap
+  local bats_teardown_trap_status=0
+
+  # `bats_teardown_trap` is always called with one parameter (BATS_TEARDOWN_STARTED)
+  # The second parameter is optional and corresponds for to the killer pid
+  # that will be forwarded to the exit trap to kill it if necessary
+  local killer_pid=${2:-}
+
+  bats_set_stacktrace_limit
+
+  # mark the start of this function to distinguish where skip is called
+  # parameter 1 will signify the reason why this function was called
+  # this is used to identify when this is called as exit trap function
+  BATS_TEARDOWN_STARTED=${1:-1}
+  teardown >>"$BATS_OUT" 2>&1 || bats_teardown_trap_status="$?"
+
+  if [[ $bats_teardown_trap_status -eq 0 ]]; then
+    BATS_TEARDOWN_COMPLETED=1
+  elif [[ -n "$BATS_TEST_COMPLETED" ]]; then
+    BATS_DEBUG_LAST_STACK_TRACE_IS_VALID=1
+    BATS_ERROR_STATUS="$bats_teardown_trap_status"
+  fi
+
+  bats_exit_trap "$killer_pid"
+}
+
+# shellcheck source=lib/bats-core/common.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/common.bash"
+
+bats_exit_trap() {
+  local status
+  local exit_metadata=''
+  local killer_pid=${1:-}
+  trap - ERR EXIT
+  if [[ -n "${BATS_TEST_TIMEOUT:-}" ]]; then
+    # Kill the watchdog in the case of of kernel finished before the timeout
+    bats_abort_timeout_countdown "$killer_pid" || status=1
+  fi
+
+  if [[ -n "$BATS_TEST_SKIPPED" ]]; then
+    exit_metadata=' # skip'
+    if [[ "$BATS_TEST_SKIPPED" != '1' ]]; then
+      exit_metadata+=" $BATS_TEST_SKIPPED"
+    fi
+  elif [[ "${BATS_TIMED_OUT-NOTSET}" != NOTSET ]]; then
+    exit_metadata=" # timeout after ${BATS_TEST_TIMEOUT}s"
+  fi
+
+  BATS_TEST_TIME=''
+  if [[ -n "$BATS_ENABLE_TIMING" ]]; then
+    get_mills_since_epoch BATS_TEST_END_TIME
+    BATS_TEST_TIME=" in "$((BATS_TEST_END_TIME - BATS_TEST_START_TIME))"ms"
+  fi
+
+  local print_bats_out="${BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS}"
+
+  local should_retry=''
+  if [[ -z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" || "${BATS_INTERRUPTED-NOTSET}" != NOTSET ]]; then
+    if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
+      # For some versions of bash, `$?` may not be set properly for some error
+      # conditions before triggering the EXIT trap directly (see #72 and #81).
+      # Thanks to the `BATS_TEARDOWN_COMPLETED` signal, this will pinpoint such
+      # errors if they happen during `teardown()` when `bats_perform_test` calls
+      # `bats_teardown_trap` directly after the test itself passes.
+      #
+      # If instead the test fails, and the `teardown()` error happens while
+      # `bats_teardown_trap` runs as the EXIT trap, the test will fail with no
+      # output, since there's no way to reach the `bats_exit_trap` call.
+      BATS_ERROR_STATUS=1
+    fi
+    if bats_should_retry_test; then
+      should_retry=1
+      status=126                # signify retry
+      rm -r "$BATS_TEST_TMPDIR" # clean up for retry
+    else
+      printf 'not ok %d %s%s\n' "$BATS_SUITE_TEST_NUMBER" "${BATS_TEST_NAME_PREFIX:-}${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" "$exit_metadata" >&3
+      if (( ${#BATS_TEST_TAGS[@]} > 0 )); then
+        printf '# tags:'
+        printf ' %s' "${BATS_TEST_TAGS[@]}"
+        printf '\n'
+      fi >&3
+      local stack_trace
+      bats_get_failure_stack_trace stack_trace
+      bats_print_stack_trace "${stack_trace[@]}" >&3
+      bats_print_failed_command "${stack_trace[@]}" >&3
+
+      if [[ $BATS_PRINT_OUTPUT_ON_FAILURE ]]; then
+        if [[ -n "${output:-}" ]]; then
+          printf "Last output:\n%s\n" "$output"
+        fi
+        if [[ -n "${stderr:-}" ]]; then
+          printf "Last stderr: \n%s\n" "$stderr"
+        fi
+      fi >>"$BATS_OUT"
+
+      print_bats_out=1
+      status=1
+      local state=failed
+    fi
+  else
+    printf 'ok %d %s%s\n' "$BATS_SUITE_TEST_NUMBER" "${BATS_TEST_NAME_PREFIX:-}${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" \
+      "$exit_metadata" >&3
+    status=0
+    local state=passed
+  fi
+
+  if [[ -z "$should_retry" ]]; then
+    printf "%s %s\t%s\n" "$state" "$BATS_TEST_FILENAME" "$BATS_TEST_NAME" >>"$BATS_RUNLOG_FILE"
+
+    if [[ $print_bats_out ]]; then
+      bats_prefix_lines_for_tap_output <"$BATS_OUT" | bats_replace_filename >&3
+    fi
+  fi
+  if [[ $BATS_GATHER_TEST_OUTPUTS_IN ]]; then
+    local try_suffix=
+    if [[ -n "$should_retry" ]]; then
+      try_suffix="-try$BATS_TEST_TRY_NUMBER"
+    fi
+    cp "$BATS_OUT" "$BATS_GATHER_TEST_OUTPUTS_IN/$BATS_SUITE_TEST_NUMBER$try_suffix-${BATS_TEST_DESCRIPTION//\//%2F}.log"
+  fi
+  rm -f "$BATS_OUT"
+  exit "$status"
+}
+
+# Marks the test as failed due to timeout.
+# The actual termination of subprocesses is done via pkill in the background
+# process in bats_start_timeout_countdown
+# shellcheck disable=SC2317
+bats_timeout_trap() {
+  BATS_TIMED_OUT=1
+  BATS_DEBUG_LAST_STACK_TRACE_IS_VALID=
+  exit 1
+}
+
+bats_get_child_processes_of() { # <parent-pid>
+  local -ri parent_pid=${1?}
+  {
+    read -ra header
+    local pid_col ppid_col
+    for ((i = 0; i < ${#header[@]}; ++i)); do
+      if [[ ${header[$i]} == "PID" ]]; then
+        pid_col=$i
+      fi
+      if [[ ${header[$i]} == "PPID" ]]; then
+        ppid_col=$i
+      fi
+    done
+    while read -ra row; do
+      if ((${row[$ppid_col]} == parent_pid)); then
+        printf "%d\n" "${row[$pid_col]}"
+      fi
+    done
+  } < <(ps -ef "$parent_pid")
+}
+
+bats_kill_childprocesses_of() { # <parent-pid>
+  local -ir parent_pid="${1?}"
+  if command -v pkill; then
+    pkill -P "$parent_pid"
+  else
+    # kill in reverse order (latest first)
+    while read -r pid; do
+      kill "$pid"
+    done < <(bats_get_child_processes_of "$parent_pid" | sort -r)
+  fi >/dev/null
+}
+
+# sets a timeout for this process
+#
+# using SIGABRT for interprocess communication.
+# Ruled out:
+# USR1/2 - not available on Windows
+# SIGALRM - interferes with sleep:
+#           "sleep(3) may be implemented using SIGALRM; mixing calls to alarm()
+#           and sleep(3) is a bad idea." ~ https://linux.die.net/man/2/alarm
+bats_start_timeout_countdown() { # <timeout>
+  local -ri timeout=$1
+  local -ri target_pid=$$
+  # shellcheck disable=SC2064
+  trap "bats_timeout_trap $target_pid" ABRT
+  if ! (command -v ps || command -v pkill) >/dev/null; then
+    printf "Error: Cannot execute timeout because neither pkill nor ps are available on this system!\n" >&2
+    exit 1
+  fi
+  # Start another process to kill the children of this process
+  (
+    sleep "$timeout" &
+    # sleep won't receive signals, so we use wait below
+    # and kill sleep explicitly when signalled to do so
+    # shellcheck disable=SC2064
+    trap "kill $!; exit 0" ABRT
+    wait
+    if kill -ABRT "$target_pid"; then
+      # get rid of signal blocking child processes (like sleep)
+      bats_kill_childprocesses_of "$target_pid"
+    fi &>/dev/null
+  ) &
+}
+
+bats_abort_timeout_countdown() {
+  # kill the countdown process, don't care if its still there
+  kill -ABRT "$1" &>/dev/null || true
+}
+
+
+if [[ -n "${EPOCHREALTIME-}"  ]]; then
+get_mills_since_epoch() { # <output-variable>
+  local -r output_variable="$1"
+  local int frac
+  # allow for different decimal separators
+  IFS=., read -r int frac <<<"$EPOCHREALTIME"
+  printf -v "$output_variable" "%d" "${int}${frac::3}"
+}
+else
+get_mills_since_epoch() { # <output-variable>
+  local -r output_variable="$1"
+  local ms_since_epoch
+  ms_since_epoch=$(bats_execute date +%s%N)
+  if [[ "$ms_since_epoch" == *N || "${#ms_since_epoch}" -lt 19 ]]; then
+    ms_since_epoch=$(($(bats_execute date +%s) * 1000))
+  else
+    ms_since_epoch=$((ms_since_epoch / 1000000))
+  fi
+  printf -v "$output_variable" "%d" "$ms_since_epoch"
+}
+fi
+
+bats_perform_test() {
+  if ! declare -F "${BATS_TEST_NAME%% *}" &>/dev/null; then
+    local quoted_test_name
+    bats_quote_code quoted_test_name "$BATS_TEST_NAME"
+    printf "bats: unknown test name %s\n" "$quoted_test_name" >&2
+    exit 1
+  fi
+
+  # is this skipped from outside ?
+  if [[ -n "${BATS_TEST_SKIPPED-}" ]]; then
+    # forward skip (with message) by overriding setup
+    # shellcheck disable=SC2317
+    setup() {
+      skip "$BATS_TEST_SKIPPED"
+    }
+  fi
+
+  local BATS_killer_pid=''
+  if [[ -n "${BATS_TEST_TIMEOUT:-}" ]]; then
+    bats_start_timeout_countdown "$BATS_TEST_TIMEOUT"
+    BATS_killer_pid=$!
+  fi
+  BATS_TEST_COMPLETED=
+  BATS_TEST_SKIPPED=${BATS_TEST_SKIPPED-}
+  BATS_TEARDOWN_COMPLETED=
+  BATS_ERROR_STATUS=
+  bats_setup_tracing
+  # use parameter to mark this call as trap call
+  # shellcheck disable=SC2064
+  trap "bats_teardown_trap as-exit-trap $BATS_killer_pid" EXIT
+
+  if [[ -n "$BATS_EXTENDED_SYNTAX" ]]; then
+    printf 'begin %d %s\n' "$BATS_SUITE_TEST_NUMBER" "${BATS_TEST_NAME_PREFIX:-}$BATS_TEST_DESCRIPTION" >&3
+  fi
+
+  get_mills_since_epoch BATS_TEST_START_TIME
+  {
+    bats_set_stacktrace_limit
+    setup "$@"
+    "$@"
+  } >>"$BATS_OUT" 2>&1 4>&1
+
+  BATS_TEST_COMPLETED=1
+  # shellcheck disable=SC2064
+  trap "bats_exit_trap $BATS_killer_pid" EXIT
+  bats_teardown_trap "" "$BATS_killer_pid" # pass empty parameter to signify call outside trap
+}
+
+trap bats_interrupt_trap INT
+
+# shellcheck source=lib/bats-core/preprocessing.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/preprocessing.bash"
+
+exec 3<&1
+
+bats_create_test_tmpdirs
+bats_evaluate_preprocessed_source
+
+readonly BATS_TEST_TAGS
+
+# use eval to parse (internally quoted!) test command into parameters
+bats_perform_test "${BATS_TEST_COMMAND[@]}"

--- a/tests/vendor/bats-core/libexec/bats-core/bats-format-cat
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-format-cat
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+trap '' INT
+
+cat

--- a/tests/vendor/bats-core/libexec/bats-core/bats-format-junit
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-format-junit
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=lib/bats-core/formatter.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/formatter.bash"
+
+BASE_PATH=.
+
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+  --base-path)
+    shift
+    normalize_base_path BASE_PATH "$1"
+    ;;
+  esac
+  shift
+done
+
+init_suite() {
+  suite_test_exec_time=0
+  # since we have to print the suite header before its contents but we don't know the contents before the header,
+  # we have to buffer the contents
+  _suite_buffer=""
+  test_result_state="" # declare for the first flush, when no test has been encountered
+}
+
+_buffer_log=
+init_file() {
+  file_count=0
+  file_failures=0
+  file_skipped=0
+  file_exec_time=0
+  test_exec_time=0
+  name=""
+  _buffer=""
+  _buffer_log=""
+  _system_out_log=""
+  test_result_state="" # mark that no test has run in this file so far
+}
+
+host() {
+  local hostname="${HOST:-}"
+  [[ -z "$hostname" ]] && hostname="${HOSTNAME:-}"
+  [[ -z "$hostname" ]] && hostname="$(uname -n)"
+  [[ -z "$hostname" ]] && hostname="$(hostname -f)"
+
+  echo "$hostname"
+}
+
+# convert $1 (time in milliseconds) to seconds
+milliseconds_to_seconds() {
+  # we cannot rely on having bc for this calculation
+  full_seconds=$(($1 / 1000))
+  remaining_milliseconds=$(($1 % 1000))
+  if [[ $remaining_milliseconds -eq 0 ]]; then
+    printf "%d" "$full_seconds"
+  else
+    printf "%d.%03d" "$full_seconds" "$remaining_milliseconds"
+  fi
+}
+
+suite_header() {
+  printf "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuites time=\"%s\">\n" "$(milliseconds_to_seconds "${suite_test_exec_time}")"
+}
+
+file_header() {
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S")
+  printf "<testsuite name=\"%s\" tests=\"%s\" failures=\"%s\" errors=\"0\" skipped=\"%s\" time=\"%s\" timestamp=\"%s\" hostname=\"%s\">\n" \
+    "$(xml_escape "${class}")" "${file_count}" "${file_failures}" "${file_skipped}" "$(milliseconds_to_seconds "${file_exec_time}")" "${timestamp}" "$(host)"
+}
+
+file_footer() {
+  printf "</testsuite>\n"
+}
+
+suite_footer() {
+  printf "</testsuites>\n"
+}
+
+print_test_case() {
+  if [[ "$test_result_state" == ok && -z "$_system_out_log" && -z "$_buffer_log" ]]; then
+    # pass and no output can be shortened
+    printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\" />\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
+  else
+    printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
+    if [[ -n "$_system_out_log" ]]; then
+      printf "        <system-out>%s</system-out>\n" "$(xml_escape "${_system_out_log}")"
+    fi
+    if [[ -n "$_buffer_log" || "$test_result_state" == not_ok ]]; then
+      printf "        <failure type=\"failure\">%s</failure>\n" "$(xml_escape "${_buffer_log}")"
+    fi
+    if [[ "$test_result_state" == skipped ]]; then
+      printf "        <skipped>%s</skipped>\n" "$(xml_escape "$test_skip_message")"
+    fi
+    printf "    </testcase>\n"
+  fi
+}
+
+xml_escape() {
+  output=${1//&/\&amp;}
+  output=${output//</\&lt;}
+  output=${output//>/\&gt;}
+  output=${output//'"'/\&quot;}
+  output=${output//\'/\&#39;}
+  # remove ANSI Color codes
+  local CONTROL_CHAR=$'\033'
+  local REGEX="$CONTROL_CHAR\[[0-9;]+m"
+  while [[ "$output" =~ $REGEX ]]; do
+      output=${output//${BASH_REMATCH[0]}/}
+  done
+  printf "%s" "$output"
+}
+
+suite_buffer() {
+  local output
+  output="$(
+    "$@"
+    printf "x"
+  )" # use x marker to avoid losing trailing newlines
+  _suite_buffer="${_suite_buffer}${output%x}"
+}
+
+suite_flush() {
+  echo -n "${_suite_buffer}"
+  _suite_buffer=""
+}
+
+buffer() {
+  local output
+  output="$(
+    "$@"
+    printf "x"
+  )" # use x marker to avoid losing trailing newlines
+  _buffer="${_buffer}${output%x}"
+}
+
+flush() {
+  echo -n "${_buffer}"
+  _buffer=""
+}
+
+log() {
+  if [[ -n "$_buffer_log" ]]; then
+    _buffer_log="${_buffer_log}
+$1"
+  else
+    _buffer_log="$1"
+  fi
+}
+
+flush_log() {
+  if [[ -n "$test_result_state" ]]; then
+    buffer print_test_case
+  fi
+  _buffer_log=""
+  _system_out_log=""
+}
+
+log_system_out() {
+  if [[ -n "$_system_out_log" ]]; then
+    _system_out_log="${_system_out_log}
+$1"
+  else
+    _system_out_log="$1"
+  fi
+}
+
+finish_file() {
+  if [[ "${class-JUNIT_FORMATTER_NO_FILE_ENCOUNTERED}" != JUNIT_FORMATTER_NO_FILE_ENCOUNTERED ]]; then
+    file_header
+    printf "%s\n" "${_buffer}"
+    file_footer
+  fi
+}
+
+finish_suite() {
+  flush_log
+  suite_header
+  suite_flush
+  finish_file # must come after suite flush to not print the last file before the others
+  suite_footer
+}
+
+bats_tap_stream_plan() { #  <number of tests>
+  :
+}
+
+init_suite
+trap finish_suite EXIT
+trap '' INT
+
+bats_tap_stream_begin() { # <test index> <test name>
+  flush_log
+  # set after flushing to avoid overriding name of test
+  name="$2"
+}
+
+bats_tap_stream_ok() { # <test index> <test name>
+  test_exec_time=${BATS_FORMATTER_TEST_DURATION:-0}
+  ((file_count += 1))
+  test_result_state='ok'
+  file_exec_time="$((file_exec_time + test_exec_time))"
+  suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
+}
+
+bats_tap_stream_skipped() { # <test index> <test name> <skip reason>
+  test_exec_time=${BATS_FORMATTER_TEST_DURATION:-0}
+  ((file_count += 1))
+  ((file_skipped += 1))
+  test_result_state='skipped'
+  test_exec_time=0
+  test_skip_message="$3"
+}
+
+bats_tap_stream_not_ok() { # <test index> <test name>
+  test_exec_time=${BATS_FORMATTER_TEST_DURATION:-0}
+  ((file_count += 1))
+  ((file_failures += 1))
+  test_result_state=not_ok
+  file_exec_time="$((file_exec_time + test_exec_time))"
+  suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
+}
+
+bats_tap_stream_comment() { # <comment text without leading '# '> <scope>
+  local comment="$1" scope="$2"
+  case "$scope" in
+  begin)
+    # everything that happens between begin and [not] ok is FD3 output from the test
+    log_system_out "$comment"
+    ;;
+  ok)
+    # non failed tests can produce FD3 output
+    log_system_out "$comment"
+    ;;
+  *)
+    # everything else is considered error output
+    log "$1"
+    ;;
+  esac
+}
+
+bats_tap_stream_suite() { # <file name>
+  flush_log
+  suite_buffer finish_file
+  init_file
+  class="${1/$BASE_PATH/}"
+}
+
+bats_tap_stream_unknown() { # <full line>
+  :
+}
+
+bats_parse_internal_extended_tap

--- a/tests/vendor/bats-core/libexec/bats-core/bats-format-pretty
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-format-pretty
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -e
+
+# shellcheck source=lib/bats-core/formatter.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/formatter.bash"
+
+BASE_PATH=.
+BATS_ENABLE_TIMING=
+
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+  -T)
+    BATS_ENABLE_TIMING="-T"
+    ;;
+  --base-path)
+    shift
+    normalize_base_path BASE_PATH "$1"
+    ;;
+  esac
+  shift
+done
+
+update_count_column_width() {
+  count_column_width=$((${#count} * 2 + 2))
+  if [[ -n "$BATS_ENABLE_TIMING" ]]; then
+    # additional space for ' in %s sec'
+    count_column_width=$((count_column_width + ${#SECONDS} + 8))
+  fi
+  # also update dependent value
+  update_count_column_left
+}
+
+update_screen_width() {
+  screen_width="$(tput cols)"
+  # also update dependent value
+  update_count_column_left
+}
+
+update_count_column_left() {
+  count_column_left=$((screen_width - count_column_width))
+}
+
+# avoid unset variables
+count=0
+screen_width=80
+update_count_column_width
+update_screen_width
+test_result=
+
+trap update_screen_width WINCH
+
+begin() {
+  test_result= # reset to avoid carrying over result state from previous test
+  line_backoff_count=0
+  go_to_column 0
+  update_count_column_width
+  buffer_with_truncation $((count_column_left - 1)) '   %s' "$name"
+  clear_to_end_of_line
+  go_to_column $count_column_left
+  if [[ -n "$BATS_ENABLE_TIMING" ]]; then
+    buffer "%${#count}s/${count} in %s sec" "$index" "$SECONDS"
+  else
+    buffer "%${#count}s/${count}" "$index"
+  fi
+  go_to_column 1
+}
+
+finish_test() {
+  move_up $line_backoff_count
+  go_to_column 0
+  buffer "$@"
+  if [[ -n "${TIMEOUT-}" ]]; then
+    set_color 2
+    if [[ -n "$BATS_ENABLE_TIMING" ]]; then
+      buffer ' [%s (timeout: %s)]' "$TIMING" "$TIMEOUT"
+    else
+      buffer ' [timeout: %s]' "$TIMEOUT"
+    fi
+  else
+    if [[ -n "$BATS_ENABLE_TIMING" ]]; then
+      set_color 2
+      buffer ' [%s]' "$TIMING"
+    fi
+  fi
+  advance
+  move_down $((line_backoff_count - 1))
+}
+
+pass() {
+  local TIMING="${1:-}"
+  finish_test ' ✓ %s' "$name"
+  test_result=pass
+}
+
+skip() {
+  local reason="$1" TIMING="${2:-}"
+  if [[ -n "$reason" ]]; then
+    reason=": $reason"
+  fi
+  finish_test ' - %s (skipped%s)' "$name" "$reason"
+  test_result=skip
+}
+
+fail() {
+  local TIMING="${1:-}"
+  set_color 1 bold
+  finish_test ' ✗ %s' "$name"
+  test_result=fail
+}
+
+timeout() {
+  local TIMING="${1:-}"
+  set_color 3 bold
+  TIMEOUT="${2:-}" finish_test ' ✗ %s' "$name"
+  test_result=timeout
+}
+
+log() {
+  case ${test_result} in
+  pass)
+    clear_color
+    ;;
+  fail)
+    set_color 1
+    ;;
+  timeout)
+    set_color 3
+    ;;
+  esac
+  buffer '   %s\n' "$1"
+  clear_color
+}
+
+summary() {
+  if [ "$failures" -eq 0 ]; then
+    set_color 2 bold
+  else
+    set_color 1 bold
+  fi
+
+  buffer '\n%d test' "$count"
+  if [[ "$count" -ne 1 ]]; then
+    buffer 's'
+  fi
+
+  buffer ', %d failure' "$failures"
+  if [[ "$failures" -ne 1 ]]; then
+    buffer 's'
+  fi
+
+  if [[ "$skipped" -gt 0 ]]; then
+    buffer ', %d skipped' "$skipped"
+  fi
+
+  if ((timed_out > 0)); then
+    buffer ', %d timed out' "$timed_out"
+  fi
+
+  not_run=$((count - passed - failures - skipped - timed_out))
+  if [[ "$not_run" -gt 0 ]]; then
+    buffer ', %d not run' "$not_run"
+  fi
+
+  if [[ -n "$BATS_ENABLE_TIMING" ]]; then
+    buffer " in $SECONDS seconds"
+  fi
+
+  buffer '\n'
+  clear_color
+}
+
+buffer_with_truncation() {
+  local width="$1"
+  shift
+  local string
+
+  # shellcheck disable=SC2059
+  printf -v 'string' -- "$@"
+
+  if [[ "${#string}" -gt "$width" ]]; then
+    buffer '%s...' "${string:0:$((width - 4))}"
+  else
+    buffer '%s' "$string"
+  fi
+}
+
+move_up() {
+  if [[ $1 -gt 0 ]]; then # avoid moving if we got 0
+    buffer '\x1B[%dA' "$1"
+  fi
+}
+
+move_down() {
+  if [[ $1 -gt 0 ]]; then # avoid moving if we got 0
+    buffer '\x1B[%dB' "$1"
+  fi
+}
+
+go_to_column() {
+  local column="$1"
+  buffer '\x1B[%dG' $((column + 1))
+}
+
+clear_to_end_of_line() {
+  buffer '\x1B[K'
+}
+
+advance() {
+  clear_to_end_of_line
+  buffer '\n'
+  clear_color
+}
+
+set_color() {
+  local color="$1"
+  local weight=22
+
+  if [[ "${2:-}" == 'bold' ]]; then
+    weight=1
+  fi
+  buffer '\x1B[%d;%dm' "$((30 + color))" "$weight"
+}
+
+clear_color() {
+  buffer '\x1B[0m'
+}
+
+_buffer=
+
+buffer() {
+  local content
+  # shellcheck disable=SC2059
+  printf -v content -- "$@"
+  _buffer+="$content"
+}
+
+prefix_buffer_with() {
+  local old_buffer="$_buffer"
+  _buffer=''
+  "$@"
+  _buffer="$_buffer$old_buffer"
+}
+
+flush() {
+  printf '%s' "$_buffer"
+  _buffer=
+}
+
+finish() {
+  flush
+  printf '\n'
+}
+
+trap finish EXIT
+trap '' INT
+
+bats_tap_stream_plan() {
+  count="$1"
+  index=0
+  passed=0
+  failures=0
+  skipped=0
+  timed_out=0
+  name=
+  update_count_column_width
+}
+
+bats_tap_stream_begin() {
+  index="$1"
+  name="$2"
+  begin
+  flush
+}
+
+bats_tap_stream_ok() {
+  index="$1"
+  name="$2"
+  ((++passed))
+
+  pass "${BATS_FORMATTER_TEST_DURATION:-}"
+}
+
+bats_tap_stream_skipped() {
+  index="$1"
+  name="$2"
+  ((++skipped))
+  skip "$3" "${BATS_FORMATTER_TEST_DURATION:-}"
+}
+
+bats_tap_stream_not_ok() {
+  index="$1"
+  name="$2"
+
+  if [[ ${BATS_FORMATTER_TEST_TIMEOUT-x} != x ]]; then
+    timeout "${BATS_FORMATTER_TEST_DURATION:-}" "${BATS_FORMATTER_TEST_TIMEOUT}s"
+    ((++timed_out))
+  else
+    fail "${BATS_FORMATTER_TEST_DURATION:-}"
+    ((++failures))
+  fi
+
+}
+
+bats_tap_stream_comment() { # <comment> <scope>
+  local scope=$2
+  # count the lines we printed after the begin text,
+  if [[ $line_backoff_count -eq 0 && $scope == begin ]]; then
+    # if this is the first line after begin, go down one line
+    buffer "\n"
+    ((++line_backoff_count)) # prefix-increment to avoid "error" due to returning 0
+  fi
+
+  ((++line_backoff_count))
+  ((line_backoff_count += ${#1} / screen_width)) # account for linebreaks due to length
+  log "$1"
+}
+
+bats_tap_stream_suite() {
+  #test_file="$1"
+  line_backoff_count=0
+  index=
+  # indicate filename for failures
+  local file_name="${1#"$BASE_PATH"}"
+  name="File $file_name"
+  set_color 4 bold
+  buffer "%s\n" "$file_name"
+  clear_color
+}
+
+line_backoff_count=0
+bats_tap_stream_unknown() { # <full line> <scope>
+  local scope=$2
+  # count the lines we printed after the begin text, (or after suite, in case of syntax errors)
+  if [[ $line_backoff_count -eq 0 && ($scope == begin || $scope == suite) ]]; then
+    # if this is the first line after begin, go down one line
+    buffer "\n"
+    ((++line_backoff_count)) # prefix-increment to avoid "error" due to returning 0
+  fi
+
+  ((++line_backoff_count))
+  ((line_backoff_count += ${#1} / screen_width)) # account for linebreaks due to length
+  buffer "%s\n" "$1"
+  flush
+}
+
+bats_parse_internal_extended_tap
+
+summary

--- a/tests/vendor/bats-core/libexec/bats-core/bats-format-tap
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-format-tap
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -e
+trap '' INT
+
+# shellcheck source=lib/bats-core/formatter.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/formatter.bash"
+
+bats_tap_stream_plan() {
+  printf "1..%d\n" "$1"
+}
+
+bats_tap_stream_begin() { #<test index> <test name>
+  :
+}
+
+bats_tap_stream_ok() { # [<test index> <test name>
+  printf "ok %d %s" "$1" "$2"
+  if [[ "${BATS_FORMATTER_TEST_DURATION-x}" != x ]]; then
+    printf " # in %d ms" "$BATS_FORMATTER_TEST_DURATION"
+  fi
+  printf "\n"
+}
+
+bats_tap_stream_not_ok() { # <test index> <test name>
+  printf "not ok %d %s" "$1" "$2"
+  if [[ "${BATS_FORMATTER_TEST_DURATION-x}" != x ]]; then
+    printf " # in %d ms" "$BATS_FORMATTER_TEST_DURATION"
+  fi
+  if [[ "${BATS_FORMATTER_TEST_TIMEOUT-x}" != x ]]; then
+    printf " # timeout after %d s" "${BATS_FORMATTER_TEST_TIMEOUT}"
+  fi
+  printf "\n"
+}
+
+bats_tap_stream_skipped() { # <test index> <test name> <reason>
+  if [[ $# -eq 3 ]]; then
+    printf "ok %d %s # skip %s\n" "$1" "$2" "$3"
+  else
+    printf "ok %d %s # skip\n" "$1" "$2"
+  fi
+}
+
+bats_tap_stream_comment() { # <comment text without leading '# '>
+  printf "# %s\n" "$1"
+}
+
+bats_tap_stream_suite() { # <file name>
+  :
+}
+
+bats_tap_stream_unknown() { # <full line>
+  printf "%s\n" "$1"
+}
+
+bats_parse_internal_extended_tap

--- a/tests/vendor/bats-core/libexec/bats-core/bats-format-tap13
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-format-tap13
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -e
+
+yaml_block_open=''
+add_yaml_entry() {
+  if [[ -z "$yaml_block_open" ]]; then
+    printf "  ---\n"
+  fi
+  printf "  %s: %s\n" "$1" "$2"
+  yaml_block_open=1
+}
+
+close_previous_yaml_block() {
+  if [[ -n "$yaml_block_open" ]]; then
+    printf "  ...\n"
+    yaml_block_open=''
+  fi
+}
+
+trap '' INT
+
+number_of_printed_log_lines_for_this_test_so_far=0
+
+# shellcheck source=lib/bats-core/formatter.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/formatter.bash"
+
+bats_tap_stream_plan() {
+  printf "TAP version 13\n"
+  printf "1..%d\n" "$1"
+}
+
+bats_tap_stream_begin() { #<test index> <test name>
+  :
+}
+
+bats_tap_stream_ok() { # <test index> <test name>
+  close_previous_yaml_block
+  number_of_printed_log_lines_for_this_test_so_far=0
+  printf "ok %d %s\n" "$1" "$2"
+  if [[ "${BATS_FORMATTER_TEST_DURATION-x}" != x ]]; then
+    add_yaml_entry "duration_ms" "${BATS_FORMATTER_TEST_DURATION}"
+  fi
+}
+
+pass_on_optional_data() {
+  if [[ "${BATS_FORMATTER_TEST_DURATION-x}" != x ]]; then
+    add_yaml_entry "duration_ms" "${BATS_FORMATTER_TEST_DURATION}"
+  fi
+  if [[ "${BATS_FORMATTER_TEST_TIMEOUT-x}" != x ]]; then
+    add_yaml_entry "timeout_sec" "${BATS_FORMATTER_TEST_TIMEOUT}"
+  fi
+}
+
+bats_tap_stream_not_ok() { # <test index> <test name>
+  close_previous_yaml_block
+  number_of_printed_log_lines_for_this_test_so_far=0
+
+  printf "not ok %d %s\n" "$1" "$2"
+  pass_on_optional_data
+}
+
+bats_tap_stream_skipped() { # <test index> <test name> <reason>
+  close_previous_yaml_block
+  number_of_printed_log_lines_for_this_test_so_far=0
+
+  printf "not ok %d %s # SKIP %s\n" "$1" "$2" "$3"
+  pass_on_optional_data
+}
+
+bats_tap_stream_comment() { # <comment text without leading '# '>
+  if [[ $number_of_printed_log_lines_for_this_test_so_far -eq 0 ]]; then
+    add_yaml_entry "message" "|" # use a multiline string for this entry
+  fi
+  ((++number_of_printed_log_lines_for_this_test_so_far))
+  printf "    %s\n" "$1"
+}
+
+bats_tap_stream_suite() { # <file name>
+  :
+}
+
+bats_tap_stream_unknown() { # <full line>
+  :
+}
+
+bats_parse_internal_extended_tap
+
+# close the final block if there was one
+close_previous_yaml_block

--- a/tests/vendor/bats-core/libexec/bats-core/bats-gather-tests
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-gather-tests
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+set -eET
+
+args=("$@")
+filter_tags_list=()
+included_tests=()
+excluded_tests=()
+
+# shellcheck source=lib/bats-core/common.bash disable=SC2153 
+source "$BATS_ROOT/lib/bats-core/common.bash"
+# shellcheck source=lib/bats-core/preprocessing.bash
+source "$BATS_ROOT/lib/bats-core/preprocessing.bash"
+
+abort() {
+  printf 'ERROR: '
+  # shellcheck disable=SC2059
+  printf "$@"
+  exit 1
+} >&2
+
+read_tags() {
+  local IFS=,
+  read -ra tags <<<"$1" || true
+  if ((${#tags[@]} > 0)); then
+    for ((i = 0; i < ${#tags[@]}; ++i)); do
+      bats_trim "tags[$i]" "${tags[$i]}"
+    done
+    bats_sort sorted_tags "${tags[@]}"
+    filter_tags_list+=("${sorted_tags[*]}")
+  else
+    filter_tags_list+=("")
+  fi
+}
+
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+    --dummy-flag)
+      ;;
+    --filter-tags)
+      shift
+      read_tags "$1"
+      ;;
+    --)
+      shift 1
+      break
+      ;;
+    *)
+      abort "Unknown flag %s in command:\nbats-gather-tests %s" "$1" "${args[*]}"
+      ;;
+  esac
+  shift 1
+done
+
+
+# shellcheck source=lib/bats-core/test_functions.bash disable=SC2153 
+# required to provide e.g. `load` for free code (some users rely on this)
+source "$BATS_ROOT/lib/bats-core/test_functions.bash"
+# _bats_test_functions_setup will be called per file further down
+
+# override test_functions.bash's version to use it for test registration
+bats_test_function() {
+  local -a tags=()
+  local description=
+
+  while (( $# > 0 )); do
+    case "$1" in
+      --description)
+        description=$2
+        shift 2
+      ;;
+      --tags)
+        IFS=, read -ra tags <<<"$2" || true
+        shift 2
+      ;;
+      --)
+        shift
+        break
+      ;;
+      *)
+        printf "ERROR: unknown option %s for bats_test_function" "$1" >&2
+        exit 1
+      ;;
+    esac
+  done
+
+  line="$BATS_TEST_FILENAME"
+  line+=$'\t'
+  line+="$*"
+  # always execute should_skip_because_of_status for its sideeffects
+  if should_skip_because_of_status || should_skip_because_of_focus || should_skip_because_of_filter_tags || should_skip_because_of_filter; then
+    return 0
+  fi
+  
+  # dereferencing ${test_names[*]} fails on older bash versions when empty -> check before
+  if [[ ${#test_names[@]} -gt 0 && " ${test_names[*]} " == *" $line "* ]]; then
+      test_dupes+=("$line")
+  fi
+  test_names+=("$line")
+
+  local args
+  printf -v args '%q ' "$@"
+  #echo "Adding test $line as '$BATS_TEST_FILENAME$args'" >&2
+  printf "%s\t%s\n" "$BATS_TEST_FILENAME" "$args" >> "$TESTS_LIST_FILE"
+}
+
+function should_skip_because_of_focus() {
+  if bats_all_in tags 'bats:focus'; then
+    if [[ $focus_mode == 1 ]]; then
+      # focused tests in focus mode should just be registered
+      :
+    else
+      # the current test enables focus mode ...
+      focus_mode=1
+      # ... -> remove previously found, unfocused tests
+      included_tests=()
+      : > "$TESTS_LIST_FILE"
+    fi
+  elif [[ $focus_mode == 1 ]]; then
+    # the current test is not focused but focus mode is enabled -> filter out
+    return 0
+    # no else -> unfocused tests outside focus mode should just be registered
+  fi
+  return 1
+}
+
+function should_skip_because_of_filter_tags() {
+  if (( ${#filter_tags_list[@]} > 0 )); then
+    for filter_tags in "${filter_tags_list[@]}"; do
+      # empty search tags only match empty test tags!
+      if [[ -z "$filter_tags" ]]; then
+        if [[ ${#tags[@]} -eq 0 ]]; then
+          return 1
+        fi
+        continue
+      fi
+      # non empty filter tags must  be processed
+      local -a positive_filter_tags=() negative_filter_tags=()
+      IFS=, read -ra filter_tags <<<"$filter_tags" || true
+      for filter_tag in "${filter_tags[@]}"; do
+        if [[ $filter_tag == !* ]]; then
+          bats_trim filter_tag "${filter_tag#!}"
+          negative_filter_tags+=("${filter_tag}")
+        else
+          positive_filter_tags+=("${filter_tag}")
+        fi
+      done
+      if bats_append_arrays_as_args positive_filter_tags -- bats_all_in tags &&
+        ! bats_append_arrays_as_args negative_filter_tags -- bats_any_in tags; then
+        return 1
+      fi
+    done
+    return 0 # skip, because no match was found
+  fi
+  return 1 # no filter tags -> nothing to skip
+}
+
+if [[ -n "${filter-}" ]]; then
+function should_skip_because_of_filter() {
+  # shellcheck disable=SC2154 # filter should be inherited as env var
+  ! [[ "$description" =~ $filter ]]
+}
+else
+function should_skip_because_of_filter() {
+  # skip this when there is no $filter
+  return 1
+}
+fi
+
+function should_skip_because_of_status() {
+  # disable this filter if not activated by $filter_status
+  return 1
+}
+
+# shellcheck disable=SC2154 # filter_status is set in the environment
+if [[ -n "${filter_status-}" ]]; then
+  case "$filter_status" in
+  failed)
+    bats_filter_test_by_status() { # <line>
+      ! bats_binary_search "$1" "passed_tests"
+    }
+    ;;
+  passed)
+    bats_filter_test_by_status() {
+      ! bats_binary_search "$1" "failed_tests"
+    }
+    ;;
+  missed)
+    bats_filter_test_by_status() {
+      ! bats_binary_search "$1" "failed_tests" && ! bats_binary_search "$1" "passed_tests"
+    }
+    ;;
+  *)
+    printf "Error: Unknown value '%s' for --filter-status. Valid values are 'failed' and 'missed'.\n" "$filter_status" >&2
+    exit 1
+    ;;
+  esac
+
+  if IFS='' read -d $'\n' -r BATS_PREVIOUS_RUNLOG_FILE < <(ls -1r "$BATS_RUN_LOGS_DIRECTORY"); then
+    BATS_PREVIOUS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/$BATS_PREVIOUS_RUNLOG_FILE"
+    if [[ $BATS_PREVIOUS_RUNLOG_FILE == "$BATS_RUNLOG_FILE" ]]; then
+      count=$(find "$BATS_RUN_LOGS_DIRECTORY" -name "$BATS_RUNLOG_DATE*" | wc -l)
+      BATS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/${BATS_RUNLOG_DATE}-$count.log"
+    fi
+    failed_tests=()
+    passed_tests=()
+    # store tests that were already filtered out in the last run for the same filter reason
+    last_filtered_tests=()
+    i=0
+    while read -rd $'\n' line; do
+      ((++i))
+      case "$line" in
+      "passed "*)
+        passed_tests+=("${line#passed }")
+        ;;
+      "failed "*)
+        failed_tests+=("${line#failed }")
+        ;;
+      "status-filtered $filter_status"*) # pick up tests that were filtered in the last round for the same status
+        last_filtered_tests+=("${line#status-filtered "$filter_status" }")
+        ;;
+      "status-filtered "*) # ignore other status-filtered lines
+        ;;
+      "#"*) # allow for comments
+        ;;
+      *)
+        printf "Error: %s:%d: Invalid format: %s\n" "$BATS_PREVIOUS_RUNLOG_FILE" "$i" "$line" >&2
+        exit 1
+        ;;
+      esac
+    done < <(sort "$BATS_PREVIOUS_RUNLOG_FILE")
+
+    # enable filter only, when there is something to filter
+    function should_skip_because_of_status() {
+      #echo "Match:" 
+      #echo "$line"
+      #printf "%s\n" "${failed_tests[@]}"
+      #echo "or"
+      #printf "%s\n" "${last_filtered_tests[@]}"
+      if bats_filter_test_by_status "$line"; then 
+        if ! bats_binary_search "$line" last_filtered_tests; then
+          included_tests+=("$line")
+          #echo "included"
+          return 1
+        fi
+      fi
+      #echo "excluded"
+      excluded_tests+=("$line")
+      return 0
+    }  >&2
+  else
+    printf "No recording of previous runs found. Running all tests!\n" >&2
+  fi
+fi
+
+# shellcheck source=lib/bats-core/tracing.bash
+source "$BATS_ROOT/lib/bats-core/tracing.bash"
+
+bats_gather_tests_exit_trap() {
+  local bats_gather_tests_exit_status=$?
+  trap - ERR EXIT DEBUG
+  if [[ ${BATS_ERROR_STATUS:-0} != 0 ]]; then
+    bats_gather_tests_exit_status=$BATS_ERROR_STATUS
+    printf "1..1\nnot ok 1 bats-gather-tests\n"
+    bats_get_failure_stack_trace stack_trace
+    bats_print_stack_trace "${stack_trace[@]}"
+    bats_print_failed_command "${stack_trace[@]}" 
+  fi >&2
+  exit "$bats_gather_tests_exit_status"
+}
+trap bats_gather_tests_exit_trap EXIT
+
+bats_set_stacktrace_limit
+
+bats_setup_tracing
+focus_mode=0
+for filename in "$@"; do
+  if [[ ! -f "$filename" ]]; then
+    abort 'Test file "%s" does not exist.\n' "${filename}"
+  fi
+
+  test_names=()
+  test_dupes=()
+
+  BATS_TEST_FILENAME="$filename"
+  _bats_test_functions_setup -1 # invalid TEST_NUMBER, as this is not a test
+
+  BATS_TEST_NAME=source
+  BATS_TEST_FILTER="$BATS_TEST_FILTER" bats_preprocess_source # uses BATS_TEST_FILENAME
+  # shellcheck disable=SC1090
+  BATS_TEST_DIRNAME="${filename%/*}" source "$BATS_TEST_SOURCE"
+
+  if [[ "${#test_dupes[@]}" -ne 0 ]]; then
+    abort 'Duplicate test name(s) in file "%s": %s' "${filename}" "${test_dupes[*]#$filename$'\t'}"
+  fi
+done
+
+if [[ -n "$filter_status" ]]; then
+  # save filtered tests to exclude them again in next round
+  for test_line in "${excluded_tests[@]}"; do
+    printf "status-filtered %s %s\n" "$filter_status" "$test_line"
+  done >>"$BATS_RUNLOG_FILE"
+
+  if [[ ${#test_names[@]} -eq 0 && ${#included_tests[@]} -eq 0 ]]; then
+    printf "There were no tests of status '%s' in the last recorded run.\n" "$filter_status" >&2
+  fi
+fi
+
+if (( focus_mode )); then
+  printf "focus_mode\n"
+fi

--- a/tests/vendor/bats-core/libexec/bats-core/bats-preprocess
+++ b/tests/vendor/bats-core/libexec/bats-core/bats-preprocess
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -e
+
+bats_encode_test_name() {
+  local name="$1"
+  local result='test_'
+  local hex_code
+
+  if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
+    name="${name//_/-5f}"
+    name="${name//-/-2d}"
+    name="${name// /_}"
+    result+="$name"
+  else
+    local length="${#name}"
+    local char i
+
+    for ((i = 0; i < length; i++)); do
+      char="${name:$i:1}"
+      if [[ "$char" == ' ' ]]; then
+        result+='_'
+      elif [[ "$char" =~ [[:alnum:]] ]]; then
+        result+="$char"
+      else
+        printf -v 'hex_code' -- '-%02x' \'"$char"
+        result+="$hex_code"
+      fi
+    done
+  fi
+
+  printf -v "$2" '%s' "$result"
+}
+
+BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
+BATS_TEST_PATTERN_COMMENT="[[:blank:]]*([^[:blank:]()]+)[[:blank:]]*\(?\)?[[:blank:]]+\{[[:blank:]]+#[[:blank:]]*@test[[:blank:]]*\$"
+BATS_COMMENT_COMMAND_PATTERN="^[[:blank:]]*#[[:blank:]]*bats[[:blank:]]+(.*)$"
+BATS_VALID_TAG_PATTERN="[-_:[:alnum:]]+"
+BATS_VALID_TAGS_PATTERN="^ *($BATS_VALID_TAG_PATTERN)?( *, *$BATS_VALID_TAG_PATTERN)* *$"
+
+# shellcheck source=lib/bats-core/common.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/common.bash"
+
+extract_tags() { # <tag_type/return_var> <tags-string>
+  local -r tag_type=$1 tags_string=$2
+  local -a tags=()
+
+  if [[ $tags_string =~ $BATS_VALID_TAGS_PATTERN ]]; then
+    IFS=, read -ra tags <<<"$tags_string"
+    local -ri length=${#tags[@]}
+    for ((i = 0; i < length; ++i)); do
+      local element="tags[$i]"
+      bats_trim "$element" "${!element}" 2>/dev/null # printf on bash 3 will complain but work anyways
+      if [[ -z "${!element}" && -n "${CHECK_BATS_COMMENT_COMMANDS:-}" ]]; then
+        printf "%s:%d: Error: Invalid %s: '%s'. " "$test_file" "$line_number" "$tag_type" "$tags_string"
+        printf "Tags must not be empty. Please remove redundant commas!\n"
+        exit_code=1
+      fi
+    done
+  elif [[ -n "${CHECK_BATS_COMMENT_COMMANDS:-}" ]]; then
+    printf "%s:%d: Error: Invalid %s: '%s'. " "$test_file" "$line_number" "$tag_type" "$tags_string"
+    printf "Valid tags must match %s and be separated with comma (and optional spaces)\n" "$BATS_VALID_TAG_PATTERN"
+    exit_code=1
+  fi >&2
+  if ((${#tags[@]} > 0)); then
+    eval "$tag_type=(\"\${tags[@]}\")"
+  else
+    eval "$tag_type=()"
+  fi
+}
+
+test_file="$1"
+test_tags=()
+# shellcheck disable=SC2034 # used in `bats_sort tags`/`extract_tags``
+file_tags=()
+line_number=0
+exit_code=0
+EMPTY_BODY_REGEX='[[:space:]]*\}'
+IFS=,
+{
+  while IFS= read -r line; do
+    ((++line_number))
+    line="${line//$'\r'/}"
+    if [[ "$line" =~ $BATS_TEST_PATTERN ]] || [[ "$line" =~ $BATS_TEST_PATTERN_COMMENT ]]; then
+      name="${BASH_REMATCH[1]#[\'\"]}"
+      name="${name%[\'\"]}"
+      body="${BASH_REMATCH[2]:-}"
+      bats_encode_test_name "$name" 'encoded_name'
+
+      if [[ "$body" =~ $EMPTY_BODY_REGEX ]]; then
+        # ":;" is needed for empty {} after test
+        lead=':; '
+      else
+        # avoid injecting non user code into tests
+        lead=''
+      fi
+      bats_append_arrays_as_args \
+        test_tags file_tags \
+        -- bats_sort tags
+
+      # shellcheck disable=SC2154 # encoded_name is declare via bats_encode_test_name
+      printf 'bats_test_function --description %q  --tags "%s" -- %s;' "$name" "${tags[*]-}" "$encoded_name"
+      printf '%s() { %s%s\n' "${encoded_name:?}" "$lead" "$body" || :
+
+      # shellcheck disable=SC2034 # used in `bats_sort tags`/`extract_tags`
+      test_tags=() # reset test tags for next test
+    else
+      if [[ "$line" =~ $BATS_COMMENT_COMMAND_PATTERN ]]; then
+        command=${BASH_REMATCH[1]}
+        case $command in
+        'test_tags='*)
+          extract_tags test_tags "${command#test_tags=}"
+          ;;
+        'file_tags='*)
+          extract_tags file_tags "${command#file_tags=}"
+          ;;
+        esac
+      fi
+      printf '%s\n' "$line"
+    fi
+  done
+} <<<"$(<"$test_file")"$'\n'
+
+exit $exit_code


### PR DESCRIPTION
## Summary
- add Bats tests that exercise the `.env` schema, MetalLB range selection, and the libvirt headless domain contract using the shared helper library
- vendor the bats-core runtime, add a headless libvirt domain fixture, and expose reusable test helpers to load repo scripts safely
- wire the new suite into `make test`, reuse the retry regression script, adjust the preflight script for sourcing, and run the suite in CI

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d089ff76588323b5776120c1a72935