### PR TITLE
Fix xorriso mkiso invocation

### DIFF
--- a/pfsense/pf-config-gen.sh
+++ b/pfsense/pf-config-gen.sh
@@ -459,7 +459,13 @@ mkiso() {
     fi
 
     attempted=1
-    if run_cmd "${cmd[@]}" -quiet -V "${ISO_LABEL}" -o "${output_path}" -J -r "${src_dir}"; then
+    local -a iso_cmd=("${cmd[@]}")
+    if [[ ${cmd[0]} != "xorriso" ]]; then
+      iso_cmd+=(-quiet)
+    fi
+    iso_cmd+=(-V "${ISO_LABEL}" -o "${output_path}" -J -r "${src_dir}")
+
+    if run_cmd "${iso_cmd[@]}"; then
       log_debug "ISO creation succeeded with ${candidate}"
       return 0
     fi


### PR DESCRIPTION
## Summary
- update the mkiso helper to only pass -quiet to tools that support it and keep the detection order unchanged

## Testing
- ./pfsense/pf-config-gen.sh


------
https://chatgpt.com/codex/tasks/task_e_68d089ff12a88323a9f611599ca1e900