### PR TITLE
feat(nextcloud): manage chart via flux

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ make up ENV_FILE=./.env
      ```
      【F:.env.example†L24-L33】【F:scripts/render_metallb_pool_manifest.sh†L1-L70】
    * **Application credentials and limits** (`LABZ_POSTGRES_DB`, `LABZ_POSTGRES_USER`, `LABZ_POSTGRES_PASSWORD`, `LABZ_REDIS_PASSWORD`, `LABZ_PHP_UPLOAD_LIMIT`).【F:.env.example†L35-L40】
+   * **Nextcloud GitOps secrets** live under `apps/nextcloud/sops-secrets/`. Decrypt each manifest with `sops` to set the admin account (`nextcloud-admin`), Redis password (`nextcloud-redis`), and PostgreSQL connection details (`nextcloud-database`) so Flux can render the HelmRelease with the proper values.【F:apps/nextcloud/sops-secrets/admin-secret.yaml†L1-L24】【F:apps/nextcloud/sops-secrets/redis-secret.yaml†L1-L18】【F:apps/nextcloud/sops-secrets/database-secret.yaml†L1-L24】
    * **pfSense and infrastructure parameters** (WAN NIC/mode, VM name, bridge hints, QCOW2 size, installer paths, cluster subdomain, Traefik VIP, and flags such as `PF_HEADLESS`).【F:.env.example†L42-L68】
 
 ## Useful targets

--- a/apps/nextcloud/sops-secrets/admin-secret.yaml
+++ b/apps/nextcloud/sops-secrets/admin-secret.yaml
@@ -1,0 +1,36 @@
+apiVersion: ENC[AES256_GCM,data:QnE=,iv:59g1PSvL/du/T6np0XOq9L2I65+oOdGsHrLpjpOF3UE=,tag:NEYa6aPKBCRqh4l3ANv+Iw==,type:str]
+kind: ENC[AES256_GCM,data:JefCtM8W,iv:dWOFFd0ZY5C6KCTRhODbM0od3akKlMeIi3Pr5IGbI0w=,tag:pDeZMCjdUoBbGIlBQ1FppQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:ZnY1fssqJWAZDDu5OLS3,iv:/wjNjusdfxrcPFRTkTXCw7GEh6kNLr97Xi5ey8znYZQ=,tag:eVJZ7hq3Z+ESa2W8xNmU2w==,type:str]
+    namespace: ENC[AES256_GCM,data:bg/CHpkIm9dH,iv:H800ytCtutM7k2B4aipKq4uQJ060gHhOF0bwNfPg1PE=,tag:c7kmd6FEHazoqjGbO2MdBQ==,type:str]
+    labels:
+        app.kubernetes.io/name: ENC[AES256_GCM,data:3M1mRyn8UwmL,iv:5Om2i0ImG83SHTSfmJk4vBcdKGpkCg7ymqAa9E1Aq4k=,tag:Qjm8eZPnlU+ON0Nnin9Ptw==,type:str]
+        app.kubernetes.io/component: ENC[AES256_GCM,data:C1aSBxug7QMhJV0=,iv:Ep6RWOjHDArnBIQfdCsW+t6mfqP7wE+thhbRV5ObNVA=,tag:jxS4HbWPpx0B7o0aK8m53w==,type:str]
+        app.kubernetes.io/instance: ENC[AES256_GCM,data:I0y4/7CtnO1V,iv:B9TPH9QJz51ZKONDN/8MgXTputuYtTEkEwNo7gMIXDU=,tag:dmFQIdz3pxpiOMMpAjtykQ==,type:str]
+    annotations:
+        reloader.stakater.com/match: ENC[AES256_GCM,data:FEeLeg==,iv:4ih8KTqpQ+m0Ie7hcHVbt0+IWAMunfp/I2uPax4eUUw=,tag:KmGJdNuo5lJSZ8ayg5K4RQ==,type:str]
+type: ENC[AES256_GCM,data:IExDje7d,iv:HoAWqx86FQz7fsZT10LLwObHgaE7oE83JLI/tEPk0AQ=,tag:9YHSAz297/yFR/25kJpsGA==,type:str]
+stringData:
+    username: ENC[AES256_GCM,data:vzvJ1rQ=,iv:90eG/6nNGshti7Wj6eaHrFpMvtpK32nJD3n+ttNwjq0=,tag:UzPvZawBObgXQ4eYIY0glg==,type:str]
+    password: ENC[AES256_GCM,data:v2/wErliZ7I=,iv:3oSqNK8K5XkALOESX2bBn3JkmrxYGT69Dk+2y8NkWLk=,tag:HiumdDYN1F79YKbCfaiEMQ==,type:str]
+    email: ENC[AES256_GCM,data:1PIPiJGzEexgxAwuClPEJzc=,iv:JOwBKOPy9R36Wvfiv9omIxzC8I+i7vxskLOE2b+4UZI=,tag:7Uftn8Dg9kf9EnkbC6kFeQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age17kdhf2edf7xq9r23zmg9v26rp60fer7tu8xy4u3d2djjqtgt3psqteva54
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4NWxMMFE2ZDFZY2Nrdm4y
+            blBDbmJNNDNJTXphYmNPTDRxb3VRV2dFOGljCkk1c1VHOXJSQVVlc3JRZ09ZMkhO
+            ekQyRWQ2eWlHeWlEMDl2TnBidnI5dDgKLS0tIDducjQzWkd3d3ZjYTREdk0rZFhl
+            dXNidk9VbVBFN1VtajF4ZWFFajUwTkkKgXS4KcYfcKgwXIcDAK5ZpCaNxvpv2I3+
+            zDXsPdBcp2HMwX43eCn1D7wVpJPEsY0zx3mDOVLV37YrqDBRbi9aww==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-09-22T15:01:12Z"
+    mac: ENC[AES256_GCM,data:OAWuzAm+b4liUWe2b2IWLhMCyE50BOF9MsLoRd0g7uDc6VY/DGWT9OfDFsYn2kgzEqAxgdRDMoHd1IeSFD0USY+GtwFxDEtsaOjbX6pvb7p5MVJFNX6LJWWwVR/xh1a2CECj62m4e9JQhPsDTZ9yc/dDIMO5mSkTLRwPzxMQVsM=,iv:V/WCx9Nh1OxYJDUCIxnYicMKkWsCGUXmJqigCz+ke4E=,tag:8eofR6BvVV/kj7M3RYaM6g==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/apps/nextcloud/sops-secrets/database-secret.yaml
+++ b/apps/nextcloud/sops-secrets/database-secret.yaml
@@ -1,0 +1,39 @@
+apiVersion: ENC[AES256_GCM,data:k6E=,iv:jT9TJ/SwyFK6pP6LPvv4Aqy9pkO793l9Dapq9VMWhNg=,tag:wzvMtEj2Vms+OAxJb9QXGA==,type:str]
+kind: ENC[AES256_GCM,data:D9YOjBc7,iv:9c28RRWuvHC21SQc8kjUJP6wuNQ5Gj5lvNF4sM4LHzQ=,tag:tT1x+quEMT9QIFZhpWXcyA==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:7SJUqd7tcItkz9JzB8KfNvDa,iv:n8vyO430ndhhtsPyt4MR0eNkSvNo1iI6OpzQcJIMems=,tag:qaA0Ktqn3kzEZoES393hgQ==,type:str]
+    namespace: ENC[AES256_GCM,data:InR8ud6FrIVz,iv:TPzQcvJ4SjNYtKv2m1j9NF0dwGMCYhqlC6JWtVUSLZw=,tag:oAyNHBqYC+o8z2PjH3hl9Q==,type:str]
+    labels:
+        app.kubernetes.io/name: ENC[AES256_GCM,data:CpqKyiBjot0W,iv:w4z6rse8Ao6rq1HgCsPGwLMj56FmGLruaLaO1AmBXY0=,tag:B4ZkHM7LlF39j6583IJBhA==,type:str]
+        app.kubernetes.io/component: ENC[AES256_GCM,data:UJshFtBvYSg=,iv:joLjlTVeBVRsDI1Er/ZaKGtL6JMhmPFxeon+HMoYd+c=,tag:osI5FtU5tdPJFyC5s2WDMw==,type:str]
+        app.kubernetes.io/instance: ENC[AES256_GCM,data:X8c/9E+5/PW9,iv:AYh6oj2gr0nVg7cDqTnQVf+MTUghlBPnfu4+ZeIGedM=,tag:DWdxzRDS8t1sfstwaCizGA==,type:str]
+    annotations:
+        reloader.stakater.com/match: ENC[AES256_GCM,data:6F6BPA==,iv:BQiao50693s/IYd42v/C109eHV+Onpbhl4ex1gJFGaI=,tag:IqBilktoUpUYmdu7RcKyiw==,type:str]
+type: ENC[AES256_GCM,data:B3zLoQVb,iv:8uyoP5HgbRZhbEXH4s2Sae2taKjiBTiwPz/J8W3FogI=,tag:R2Z5dJsF5wcWXcmBKOqqvg==,type:str]
+stringData:
+    dsn: ENC[AES256_GCM,data:02Cd/KnvIoQGIdCSdGOzeQJYXIGQSMrbmkfsChYnEhe8Z1Tc3CelzErnI4rtnfzrw87B5dH8E/kGTu9rPXs54GWMqm82Piw1u6W/5TMMsICILTR9xg==,iv:rbOu1QK9H2P6ooFdLK5BHyZFtyXRR2yN5uL4uwHxcAw=,tag:SxYcgCxK9V+DUYqUxde6Jw==,type:str]
+    host: ENC[AES256_GCM,data:cz+yC4NIcKfG+43fZN8y7hYyq/GY3NZfATxwFoDI67TOB5udtWk=,iv:9mFBtBIyB9d3pj7Y7CXrZ1hMpUlE0zsqyFkZuI8BANI=,tag:wFzkmAYl4w5Kugtj8F94Ag==,type:str]
+    port: ENC[AES256_GCM,data:5iTaFA==,iv:HGqT5Du4dF+etReNRL5RFlCu7TvGFfZ2ppwtjAfTaqA=,tag:aFDzl8wAmOLHV0i07rL50Q==,type:str]
+    database: ENC[AES256_GCM,data:aPBLQ03x2Dql,iv:otNl036FJtyos5nuk0t3WOCrIFuv2owYj+zMdHFBjss=,tag:+2Fqo43byOUW2SeP44pMgw==,type:str]
+    username: ENC[AES256_GCM,data:tJuIkB1VZVv/,iv:opSMTvi2ydtb4HMIEooaoTMYvcTEXNGA2ba7r99GjW4=,tag:p524apWoay2ySxEVcsJYCA==,type:str]
+    password: ENC[AES256_GCM,data:tyE0nJYTgto=,iv:MA7ZXX1pe5WtkmMuPHnETL3ho6k5UEpCNBPgxx1SG2g=,tag:jqhf0/Xdm+5NFeHWdHW6Fg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age17kdhf2edf7xq9r23zmg9v26rp60fer7tu8xy4u3d2djjqtgt3psqteva54
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCRFcwbk05d0ZNNlAyWVNn
+            Z3dRZVNyRzZvcnk3UVkvRzRUMVVRa1FXdXhjCkUrbUszRXR2Z0ZpZUtSQkxqTWp1
+            anVlOWVCQjFYZFk2MHFKU3JsODUxY1UKLS0tIDR6bkVSMnZRaG5TTWFOb3ZiaDhK
+            QldNaDZpcEtpeWpVcHNOeFRQYXp2VUUK2Hu07uWznofk/6VSUzFyY3EnVglDcjdE
+            Tk81QHcmt1Khe4/nhdCrxWiOVAdtBhKdfRPZFLZSeqpeKQ0wjjEgfg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-09-22T15:01:12Z"
+    mac: ENC[AES256_GCM,data:GxxcXNtGF+VcToSt/UECgOxnjbY6opx+oBsmQZsjiZlwpFQzIr2TI585mDiWEZ4gFpzN/sAxhiB/iRh4+QQzkmiQfwb0Y0cF4GqWtBMIoK7d17VH2tfMIMICURdR/gUrTCv/Nm2gOc/maDThul77T45Ptg8eToeRe7c0wYgUnpc=,iv:NclZYXX3Fkv+fpMvGNQjjXl5DXmOP8cD/HestDuVXXc=,tag:CEMGsf6HpVXrsW2r41PG4Q==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/apps/nextcloud/sops-secrets/redis-secret.yaml
+++ b/apps/nextcloud/sops-secrets/redis-secret.yaml
@@ -1,0 +1,34 @@
+apiVersion: ENC[AES256_GCM,data:Yno=,iv:0Qium0Z2u4SxuQzcYqmrrMADMEQzTiDtqVzXvVXAAho=,tag:oXYNOJW77UN3+zwxahg6bQ==,type:str]
+kind: ENC[AES256_GCM,data:ftT/5zwy,iv:W3Tbz012bpndm/N1f4rtURvb3WrLAFV/QoxVTITZFTE=,tag:B0XRM6K8KfVoptx6jW3btQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:0XS/W/5AcAYhfdC77jC+,iv:+uUn5kydplu+nr2WcVOyoeHvW+IGcbb/hNLFQQodjiM=,tag:phq785hHGobwgJ5BYhtd/g==,type:str]
+    namespace: ENC[AES256_GCM,data:FPUrydFaPUGl,iv:PP+Hp/Ee5hOz5/EUfluJFzvmxE+kKpCzTHDAPW2U680=,tag:i8fwOXT5MN0aDXAiCZNVzg==,type:str]
+    labels:
+        app.kubernetes.io/name: ENC[AES256_GCM,data:lkwqC++Z9gj0,iv:26fHAAowoSd96AAj3KDcOTyDTb/SNUVVt/wkfyIIjgo=,tag:Pw/ORvH5mHGvLzXVDLpGgA==,type:str]
+        app.kubernetes.io/component: ENC[AES256_GCM,data:9uWSK+g=,iv:kRMLI6hyyRWfUviQPneWT8Jz/vjK0ORq+NozjmZpo4Q=,tag:KDStUfdlz+wP3hToM10BDg==,type:str]
+        app.kubernetes.io/instance: ENC[AES256_GCM,data:2wGkTN73x625,iv:xqMsr27N4pei9n/JdSkfjUHbMZHuYAbIHrbBdBTG8uU=,tag:8cr9tU3pgSc/JwzSPmcIfQ==,type:str]
+    annotations:
+        reloader.stakater.com/match: ENC[AES256_GCM,data:+Q3qUA==,iv:S+pTF5iVe9FOb791KQ0+XGF4sVK14sScepYXTXH34hY=,tag:yqBc3WP1lT7i6X5bAKeV+w==,type:str]
+type: ENC[AES256_GCM,data:HPQdzBun,iv:+zpefSnG3G5jbz3vuX1bw/yZbRs1D4leGQM6skKfqNs=,tag:1GjKmVOFSfJfnkjx/dcwUw==,type:str]
+stringData:
+    password: ENC[AES256_GCM,data:pZfMJw9xokk=,iv:62qVYgU4wSWpMN+eVEaq1sw4Nt3GXWk5FEnHsUAd9kk=,tag:FCn+6Z7tjGsVWcV/KHNXUQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age17kdhf2edf7xq9r23zmg9v26rp60fer7tu8xy4u3d2djjqtgt3psqteva54
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGZDFCSnVOcWNJWXc2QUJF
+            VC9aYzAzQXNVTEllS05TazcxVlUwUEVnMEE0ClZLNmZlZXprNzBqdi92QmF6QmJQ
+            bXVEbnhJMEFSWVc1TExpWk4xbS9JejQKLS0tIEsxZzB2U2JOZWRKUkpIYlQvL3pm
+            UnlhVFg3djA0RnF5Tk9kenFaSXFGNlUKatcYqbF1Jxzg5x3WPWJAdIe9l9N32pX1
+            UvbDgvzkHtqjED8PbohlAlxCh/k3DOsQ6Hf+M7wco979j4JzZ5yibg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-09-22T15:01:12Z"
+    mac: ENC[AES256_GCM,data:ItgNUvEpHBOdPLDfdhyQU9eBiw79dDPfc1RM8c0n5X/ElBSnwnWkY51qZura1qMRkPldnHPWoOuEEWPLb7LsTCKlGWBre3IzLgGp/3yddnnn5AGVL+u0cScr4cjp+S+h9qX/2LfFXLmYz7/foe2HkR1+ghBaKvQvTJ4Zh0gx5DM=,iv:Ubbof8suIxpQTK+xewSfG+ezthdZiZSTr90wVVdFULI=,tag:WlIohHeKng+Uq7gn5SB+Rg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/k8s/apps/nextcloud/certificate.yaml
+++ b/k8s/apps/nextcloud/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: labz-apps-tls
+  namespace: nextcloud
+spec:
+  secretName: labz-apps-tls
+  dnsNames:
+    - nextcloud.labz.example.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: labz-selfsigned

--- a/k8s/apps/nextcloud/helmrelease.yaml
+++ b/k8s/apps/nextcloud/helmrelease.yaml
@@ -1,0 +1,112 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nextcloud
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: nextcloud
+  targetNamespace: nextcloud
+  dependsOn:
+    - name: pg
+      namespace: flux-system
+    - name: traefik-ingress
+      namespace: flux-system
+    - name: cert-manager
+      namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+      strategy: uninstall
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+      strategy: uninstall
+  timeout: 10m0s
+  chart:
+    spec:
+      chart: nextcloud
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system
+  values:
+    fullnameOverride: nextcloud
+    nextcloudHost: nextcloud.labz.example.com
+    extraEnvVars:
+      - name: DATABASE_URL
+        value: ""
+    ingress:
+      enabled: true
+      ingressClassName: traefik
+      hostname: nextcloud.labz.example.com
+      tls:
+        - hosts:
+            - nextcloud.labz.example.com
+          secretName: labz-apps-tls
+    persistence:
+      enabled: true
+      existingClaim: nextcloud-data
+    mariadb:
+      enabled: false
+    postgresql:
+      enabled: false
+    redis:
+      enabled: false
+    externalDatabase:
+      enabled: true
+      type: postgresql
+      host: postgresql.databases.svc.cluster.local
+      port: 5432
+    externalCache:
+      enabled: true
+      host: redis-master.data.svc.cluster.local
+      port: 6379
+    phpClient:
+      maxUploadSize: 10G
+    podSecurityContext:
+      enabled: true
+      fsGroup: 33
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 33
+      runAsGroup: 33
+  valuesFrom:
+    - kind: Secret
+      name: nextcloud-admin
+      valuesKey: username
+      targetPath: nextcloudUsername
+    - kind: Secret
+      name: nextcloud-admin
+      valuesKey: password
+      targetPath: nextcloudPassword
+    - kind: Secret
+      name: nextcloud-admin
+      valuesKey: email
+      targetPath: nextcloudEmail
+    - kind: Secret
+      name: nextcloud-redis
+      valuesKey: password
+      targetPath: externalCache.password
+    - kind: Secret
+      name: nextcloud-database
+      valuesKey: host
+      targetPath: externalDatabase.host
+    - kind: Secret
+      name: nextcloud-database
+      valuesKey: username
+      targetPath: externalDatabase.user
+    - kind: Secret
+      name: nextcloud-database
+      valuesKey: password
+      targetPath: externalDatabase.password
+    - kind: Secret
+      name: nextcloud-database
+      valuesKey: database
+      targetPath: externalDatabase.database
+    - kind: Secret
+      name: nextcloud-database
+      valuesKey: dsn
+      targetPath: extraEnvVars[0].value

--- a/k8s/apps/nextcloud/kustomization.yaml
+++ b/k8s/apps/nextcloud/kustomization.yaml
@@ -1,3 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+  - namespace.yaml
+  - helmrelease.yaml
+  - certificate.yaml
+  - ../../../apps/nextcloud/sops-secrets/admin-secret.yaml
+  - ../../../apps/nextcloud/sops-secrets/redis-secret.yaml
+  - ../../../apps/nextcloud/sops-secrets/database-secret.yaml

--- a/k8s/apps/nextcloud/namespace.yaml
+++ b/k8s/apps/nextcloud/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextcloud
+  labels:
+    kubernetes.io/metadata.name: nextcloud

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ../data/postgres
   - ../apps/awx
   - ../apps/django-multiproject
+  - ../apps/nextcloud


### PR DESCRIPTION
## Summary
- add a Flux-managed Nextcloud namespace, HelmRelease, and certificate aligned with the manual install configuration
- store Nextcloud admin, Redis cache, and PostgreSQL DSN credentials as SOPS secrets and reference them from the chart values
- document the new secret workflow and include the Nextcloud overlay in the base kustomization

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68d162a3f83883238891100d396e42db