### PR TITLE
Add Homepage application manifests

### DIFF
--- a/apps/homepage/sops-secrets/homepage-secrets.yaml
+++ b/apps/homepage/sops-secrets/homepage-secrets.yaml
@@ -1,0 +1,28 @@
+apiVersion: ENC[AES256_GCM,data:KKM=,iv:tLtFB2XxgGyLlvIeRrYr/+A8cAZTZIda4xjoW540UIQ=,tag:D9PdJdcutwDh+YagdJXcuw==,type:str]
+kind: ENC[AES256_GCM,data:lm64fe06,iv:ztSgdQ8qHQWSqkZ3y78v9LoiJyHq3XxhuZSIvjyfAsw=,tag:iZV+V8a/ywb4z0W3DwS6bg==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:mqmFAhR9dJuFhJFes41VYw==,iv:rAyGVCsHp8zyye0wc1SW0QlWXUV1lI1aVMNlAu11O94=,tag:Wbk5poj2R0PjvkHqenAFBw==,type:str]
+    namespace: ENC[AES256_GCM,data:9KRKJd0UW0o=,iv:o1e5vSFkFDr/lJF9PhqJT0iY7YM/HdjMzSJnSWUYF/I=,tag:zMn8++r84h/kycb63zInYg==,type:str]
+type: ENC[AES256_GCM,data:ZkptxvQp,iv:wnHTGIRXm2wrnbJu2qfQBz+VkRyjBO5sKlbXpjNqUAE=,tag:kTL09CcH/b+UxPeH/eDk7w==,type:str]
+stringData:
+    secrets.yaml: ENC[AES256_GCM,data:myQnuz+YJCGBTwO5mGPnuCO7eC093XvI51vD1utRN6m9Ta8PVPTqfH60MwC2+ccfLDZhF2wIHzxx,iv:2XfAPE3vxiTCeuwQyIsbX8D+7SHxbzkiJxZmyZmpWOY=,tag:k49OhQqMpS7iwunMmFsHjg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age17kdhf2edf7xq9r23zmg9v26rp60fer7tu8xy4u3d2djjqtgt3psqteva54
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhSmdnQ1Y3bE1zOFRzdDJr
+            eWJhdjNiY2hCU3d5Y1lHcXVHcDNEOVYrMzA0Ci95QWUwTUZ4YlEvcHE0ckJLdncy
+            UkFLeXBPb2NGcHA4TEJZK0UzbU5kNzgKLS0tIE5mZmxlSmRsQU1yRkw3SWVsTy9D
+            d29qRUd5TmhWQU45K0QvYXIwVEpIeTQKll28OQiSohrOMrztJiCqBf9E6mgwVPMt
+            BJjTD9nCBHJuKJrL94FKCsz6txmQqnu2lhAFCnGIphFvA9IIzlwQtQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-09-22T15:00:23Z"
+    mac: ENC[AES256_GCM,data:9VoRTafBZLJAHCHEcJvgwG+gj1+huB5ChiWJsASfWK3WGYH9ZyCSe/FsZRb5RIeZpjH8L4KyrIRdYIXHU/fff5SJsNVTRvhMI4je8PcaqBfhvIq3idkR74XEsVXzqErZdYtf7k4/bE4Wd3AQhgkqSl97faZ0/sInOterlFX+1zM=,iv:P9QG7J1pkzNoUfwe4kid8h+pzbURKw37iLSj0fgBuzk=,tag:k3vECt9IzWXg+PW749mlCw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -28,6 +28,7 @@ The environment stitches together on-premises virtualization, Kubernetes tooling
 ### User-Facing Applications
 
 - **AWX** provides Ansible automation inside the `awx` namespace with persistent volumes and TLS termination handled by Traefik.
+- **Homepage** publishes the default landing page for the homelab at `https://home.lab-minikube.labz.home.arpa/`, loading its layout from `k8s/apps/homepage/configmap.yaml` and pulling widget credentials (`openweathermap_api_key`, `uptime_kuma_api_key`) from the SOPS-encrypted secret at `apps/homepage/sops-secrets/homepage-secrets.yaml`.
 - **Django Multiproject Demo** showcases the platform deployment pipeline, including container image preloading via `apps/django-multiproject/load-image.sh`.
 - **Observability stack** is powered by `kube-prometheus-stack`, exposing Grafana, Prometheus, and Alertmanager through Traefik-managed Ingresses.
 
@@ -58,6 +59,17 @@ Bounce the AWX pods if the operator does not reconcile automatically.
 #### Rotate Postgres Superuser Credentials
 
 The bootstrap Postgres chart consumes `data/postgres/sops-secrets/postgres-superuser.yaml` for the `pg-superuser` secret. When changing the password, ensure the `stringData.postgres-password` field and the `stringData.database-url` connection string stay in sync before applying the manifest.
+
+#### Homepage API Keys
+
+The Homepage dashboard reads its widget credentials from `apps/homepage/sops-secrets/homepage-secrets.yaml`. The secret must define `openweathermap_api_key` for the weather widget and `uptime_kuma_api_key` for the Uptime Kuma status widget referenced in `k8s/apps/homepage/configmap.yaml`.
+
+1. Open the manifest with SOPS:
+   ```bash
+   sops apps/homepage/sops-secrets/homepage-secrets.yaml
+   ```
+2. Update the API keys under the `secrets.yaml` document.
+3. Save and exit so SOPS re-encrypts the file, then commit the change or apply it manually (`kubectl apply -f apps/homepage/sops-secrets/homepage-secrets.yaml`).
 
 ### Grafana Admin Credential Management
 

--- a/k8s/apps/homepage/certificate.yaml
+++ b/k8s/apps/homepage/certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: homepage-tls
+spec:
+  secretName: homepage-tls
+  dnsNames:
+    - home.lab-minikube.labz.home.arpa
+  issuerRef:
+    name: labz-ca-issuer
+    kind: ClusterIssuer

--- a/k8s/apps/homepage/configmap.yaml
+++ b/k8s/apps/homepage/configmap.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homepage-config
+data:
+  settings.yaml: |
+    title: Homelab Launchpad
+    theme: dark
+    layout:
+      - Overview:
+          style: columns
+          columns: 3
+    kubernetes:
+      mode: cluster
+      clusterName: lab-minikube
+    header: true
+    footer: false
+  services.yaml: |
+    - Infrastructure:
+        - Homepage:
+            href: https://home.lab-minikube.labz.home.arpa
+            icon: mdi-home-circle
+            description: Primary landing page for homelab links
+        - Traefik:
+            href: https://traefik.labz.home.arpa/dashboard/
+            icon: traefik
+            description: Reverse proxy and ingress controller
+  bookmarks.yaml: |
+    - Documentation:
+        - Repository:
+            href: https://github.com/uranus-lab/homelab-gitops
+            icon: mdi-git
+        - Runbooks:
+            href: https://docs.lab-minikube.labz.home.arpa
+            icon: mdi-book-open-page-variant
+  widgets.yaml: |
+    - search:
+        provider: duckduckgo
+    - weather:
+        label: Home
+        provider: openweathermap
+        units: imperial
+        latitude: 41.8781
+        longitude: -87.6298
+        apiKey: !secret openweathermap_api_key
+    - uptimekuma:
+        url: https://status.labz.home.arpa
+        slug: lab-status
+        apiKey: !secret uptime_kuma_api_key

--- a/k8s/apps/homepage/deployment.yaml
+++ b/k8s/apps/homepage/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homepage
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: homepage
+    spec:
+      containers:
+        - name: homepage
+          image: ghcr.io/gethomepage/homepage:v0.8.8
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: TZ
+              value: UTC
+          volumeMounts:
+            - name: homepage-config
+              mountPath: /app/config
+            - name: homepage-secrets
+              mountPath: /app/config/secrets.yaml
+              subPath: secrets.yaml
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+      volumes:
+        - name: homepage-config
+          configMap:
+            name: homepage-config
+        - name: homepage-secrets
+          secret:
+            secretName: homepage-secrets
+            optional: false

--- a/k8s/apps/homepage/ingress.yaml
+++ b/k8s/apps/homepage/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homepage
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  tls:
+    - secretName: homepage-tls
+      hosts:
+        - home.lab-minikube.labz.home.arpa
+  rules:
+    - host: home.lab-minikube.labz.home.arpa
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homepage
+                port:
+                  number: 80

--- a/k8s/apps/homepage/kustomization.yaml
+++ b/k8s/apps/homepage/kustomization.yaml
@@ -1,3 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+namespace: homepage
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - certificate.yaml
+  - ingress.yaml
+  - ../../../apps/homepage/sops-secrets/homepage-secrets.yaml

--- a/k8s/apps/homepage/namespace.yaml
+++ b/k8s/apps/homepage/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homepage
+  labels:
+    app.kubernetes.io/name: homepage

--- a/k8s/apps/homepage/service.yaml
+++ b/k8s/apps/homepage/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homepage
+  labels:
+    app.kubernetes.io/name: homepage
+spec:
+  selector:
+    app.kubernetes.io/name: homepage
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  type: ClusterIP

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ../data/postgres
   - ../apps/awx
   - ../apps/django-multiproject
+  - ../apps/homepage


### PR DESCRIPTION
## Summary
- add Kubernetes resources for the Homepage dashboard including namespace, deployment, service, TLS, and routing
- create a SOPS-encrypted secret for Homepage widget credentials and include the app in the base kustomization
- document the expected Homepage API keys alongside the GitOps reference material

## Testing
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68d162aebfa0832381dc5a36890db839