### PR TITLE
Add reusable environment loader script

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -12,6 +12,9 @@ if [[ -n ${_HOMELAB_COMMON_SH_SOURCED:-} ]]; then
 fi
 readonly _HOMELAB_COMMON_SH_SOURCED=1
 
+# shellcheck source=./load-env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/load-env.sh"
+
 : "${LOG_LEVEL:=info}"
 
 _homelab_ts() {
@@ -278,26 +281,6 @@ wait_for_port_forwards() {
       wait "${pid}" || true
     fi
   done
-}
-
-load_env() {
-  if [[ $# -ne 1 ]]; then
-    log_error "Usage: load_env <env-file>"
-    return 64
-  fi
-  local env_file=$1
-  if [[ ! -f $env_file ]]; then
-    log_error "Environment file not found: $env_file"
-    return 1
-  fi
-
-  log_debug "Loading environment from $env_file"
-  local prev_state
-  prev_state=$(set +o)
-  set -a
-  # shellcheck disable=SC1090
-  source "$env_file"
-  eval "$prev_state"
 }
 
 metallb_render_ip_pool_manifest() {

--- a/scripts/lib/common_fallback.sh
+++ b/scripts/lib/common_fallback.sh
@@ -9,6 +9,9 @@ if [[ -n ${_HOMELAB_COMMON_FALLBACK_SH_SOURCED:-} ]]; then
 fi
 readonly _HOMELAB_COMMON_FALLBACK_SH_SOURCED=1
 
+# shellcheck source=./load-env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/load-env.sh"
+
 : "${LOG_LEVEL:=info}"
 
 _homelab_fallback_ts() {
@@ -276,26 +279,6 @@ wait_for_port_forwards() {
       wait "${pid}" || true
     fi
   done
-}
-
-load_env() {
-  if [[ $# -ne 1 ]]; then
-    log_error "Usage: load_env <env-file>"
-    return 64
-  fi
-  local env_file=$1
-  if [[ ! -f $env_file ]]; then
-    log_error "Environment file not found: $env_file"
-    return 1
-  fi
-
-  log_debug "Loading environment from $env_file"
-  local prev_state
-  prev_state=$(set +o)
-  set -a
-  # shellcheck disable=SC1090
-  source "$env_file"
-  eval "$prev_state"
 }
 
 homelab_resolve_existing_dir() {

--- a/scripts/lib/load-env.sh
+++ b/scripts/lib/load-env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+load_env() {
+  if [[ $# -ne 1 ]]; then
+    printf 'Usage: load_env <env-file>\n' >&2
+    return 64
+  fi
+
+  local env_file="$1"
+  if [[ ! -f ${env_file} ]]; then
+    printf 'Environment file not found: %s\n' "${env_file}" >&2
+    return 1
+  fi
+
+  printf '[INFO] Using .env: %s\n' "${env_file}"
+
+  local previous_opts
+  previous_opts=$(set +o)
+  set -a
+  # shellcheck disable=SC1090
+  source "${env_file}"
+  eval "${previous_opts}"
+}


### PR DESCRIPTION
## Summary
- add scripts/lib/load-env.sh implementing the shared load_env helper with the required [INFO] output
- source the new helper from common and fallback libraries to remove the duplicated loader logic

## Testing
- tests/vendor/bats-core/bin/bats tests/bats

------
https://chatgpt.com/codex/tasks/task_e_68d170aefeec83238f86f9d411dadd0d