### PR TITLE
Update Makefile env handling and add net ensure script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,159 +1,154 @@
 SHELL := /bin/bash
-.ONESHELL:
 .SHELLFLAGS := -eu -o pipefail -c
+.ONESHELL:
+.RECIPEPREFIX := >
 
 ENV_FILE ?= ./.env
+export ENV_FILE
+
+NET_CREATE ?=
 PF_VM_NAME ?= pfsense-uranus
 BATS ?= tests/vendor/bats-core/bin/bats
 
-.PHONY: help docs
+.PHONY: help doctor docs check.env net.ensure preflight pf.config pf.install pf.ztp pf.smoketest \
+        k8s.up k8s.bootstrap k8s.smoketest status up test lint ci
+
 help:
-	@echo "Targets:"
-	@echo "  test            - Run repository test suite"
-	@echo "  lint            - Run linting checks"
-	@echo "  ci              - Run linting and tests"
-	@echo "  up              - Run full bootstrap: pfSense + Kubernetes + status"
-	@echo "  net.ensure      - Ensure WAN/LAN bridges are present"
-	@echo "  preflight       - Ensure pfSense VM is running & IPs sane"
-	@echo "  pf.config       - Render pfSense config ISO/assets"
-	@echo "  pf.install      - Stage installer media and run pf-ztp (virt-install + wiring)"
-	@echo "  pf.ztp          - Re-run pf-ztp to refresh installer/media wiring"
-	@echo "  pf.smoketest    - Run pfSense smoketest"
-	@echo "  k8s.up          - Prepare kubectl context for the homelab cluster"
-	@echo "  k8s.bootstrap   - Bootstrap Minikube and MetalLB"
-	@echo "  k8s.smoketest   - Validate Kubernetes readiness"
-	@echo "  status          - Emit current bootstrap status marker"
-	@echo "  check.env       - Show key environment values"
-	@echo "  docs            - Build the MkDocs documentation site"
+> @printf "Homelab GitOps automation\n"
+> @printf "=========================\n\n"
+> @printf "Environment variables:\n"
+> @printf "  ENV_FILE=<path>   Path to the environment overrides file (default: ./.env).\n"
+> @printf "  NET_CREATE=1      Allow net.ensure to define missing libvirt networks.\n\n"
+> @printf "Targets:\n"
+> @printf "  help             Show this help message.\n"
+> @printf "  doctor           Run non-mutating diagnostics against the host.\n"
+> @printf "  check.env        Summarize environment configuration and live status.\n"
+> @printf "  net.ensure       Ensure pfSense bridges and libvirt networks exist.\n"
+> @printf "  preflight        Verify pfSense VM readiness and required IP settings.\n"
+> @printf "  pf.config        Render pfSense configuration assets.\n"
+> @printf "  pf.install       Prepare installer media and run pfSense zero-touch provisioning.\n"
+> @printf "  pf.ztp           Re-run pfSense zero-touch provisioning helpers.\n"
+> @printf "  pf.smoketest     Validate pfSense networking via smoketests.\n"
+> @printf "  k8s.up           Configure kubectl context for the homelab cluster.\n"
+> @printf "  k8s.bootstrap    Bootstrap Minikube and MetalLB.\n"
+> @printf "  k8s.smoketest    Validate Kubernetes readiness.\n"
+> @printf "  status           Emit the current bootstrap status marker.\n"
+> @printf "  up               Run the full homelab bootstrap workflow.\n"
+> @printf "  lint             Run linting checks.\n"
+> @printf "  test             Run repository test suite.\n"
+> @printf "  ci               Run linting and tests.\n"
 
-.PHONY: docs
-docs:
-	@echo "Building documentation with MkDocs..."
-	@mkdocs build
+# ---------------------------------------------------------------------------
+# Host utilities
+# ---------------------------------------------------------------------------
 
-.PHONY: check.env
+doctor:
+> @echo "Running host diagnostics..."
+> @./scripts/host-prep.sh --env-file "$(ENV_FILE)" --context-preflight
+
 check.env:
-	@echo "Using environment file $(ENV_FILE)"
-	@test -f $(ENV_FILE) && grep -E '^(LAN_CIDR|LAN_GW_IP|PF_VM_NAME|PF_LAN_BRIDGE|PF_WAN_BRIDGE|WAN_MODE|WAN_NIC|PF_OSINFO|PF_INSTALLER_SRC|LABZ_METALLB_RANGE|TRAEFIK_LOCAL_IP)=' $(ENV_FILE) || true
+> @./scripts/status.sh --env-file "$(ENV_FILE)"
 
-.PHONY: net.ensure
+# ---------------------------------------------------------------------------
+# pfSense helpers
+# ---------------------------------------------------------------------------
+
 net.ensure:
-	@echo "Ensuring pfSense network bridges exist..."
-	@chmod +x ./scripts/net-ensure-bridge.sh
-	@if [[ -f "$(ENV_FILE)" ]]; then source "$(ENV_FILE)"; else echo "Environment file $(ENV_FILE) not found" >&2; exit 1; fi
-	@: "$${PF_WAN_BRIDGE:?PF_WAN_BRIDGE must be set in $(ENV_FILE)}"
-	@: "$${PF_LAN_BRIDGE:?PF_LAN_BRIDGE must be set in $(ENV_FILE)}"
-	@./scripts/net-ensure-bridge.sh "$$PF_WAN_BRIDGE"
-	@./scripts/net-ensure-bridge.sh "$$PF_LAN_BRIDGE"
+> @NET_CREATE="$(NET_CREATE)" ./scripts/net-ensure.sh --env-file "$(ENV_FILE)"
 
-.PHONY: preflight
 preflight:
-	@echo "Running pfSense preflight..."
-	@chmod +x ./scripts/pf-preflight.sh
-	@./scripts/pf-preflight.sh --env-file "$(ENV_FILE)"
+> @./scripts/pf-preflight.sh --env-file "$(ENV_FILE)"
 
-.PHONY: pf.config
 pf.config:
-	@echo "Rendering pfSense config from $(ENV_FILE)"
-	@sudo -E ./pfsense/pf-config-gen.sh --env-file "$(ENV_FILE)"
+> @sudo -E ./pfsense/pf-config-gen.sh --env-file "$(ENV_FILE)"
 
-.PHONY: pf.install
 pf.install:
-	@echo "Preparing pfSense installer media..."
-	@chmod +x ./scripts/pf-installer-prepare.sh ./scripts/pf-ztp.sh
-	@sudo -E ./scripts/pf-installer-prepare.sh --env-file "$(ENV_FILE)"
-	@echo "Ensuring pfSense VM and bootstrap media via pf-ztp..."
-	@sudo -E ./scripts/pf-ztp.sh --env-file "$(ENV_FILE)"
+> @sudo -E ./scripts/pf-installer-prepare.sh --env-file "$(ENV_FILE)"
+> @sudo -E ./scripts/pf-ztp.sh --env-file "$(ENV_FILE)"
 
-.PHONY: pf.ztp
 pf.ztp:
-	@echo "Running pfSense ZTP..."
-	@chmod +x ./scripts/pf-ztp.sh
-	@sudo -E ./scripts/pf-ztp.sh --env-file "$(ENV_FILE)"
-	@echo "pfSense ZTP done."
+> @sudo -E ./scripts/pf-ztp.sh --env-file "$(ENV_FILE)"
 
-.PHONY: pf.smoketest
 pf.smoketest:
-	@chmod +x ./scripts/pf-smoketest.sh
-	@if [[ -f "$(ENV_FILE)" ]]; then source "$(ENV_FILE)"; else echo "Environment file $(ENV_FILE) not found" >&2; exit 1; fi
-	@: "$${PF_LAN_BRIDGE:?PF_LAN_BRIDGE must be set in $(ENV_FILE)}"
-	@./scripts/pf-smoketest.sh --env-file "$(ENV_FILE)" --lan-bridge "$$PF_LAN_BRIDGE"
+> @./scripts/pf-smoketest.sh --env-file "$(ENV_FILE)"
 
-.PHONY: k8s.up
+# ---------------------------------------------------------------------------
+# Kubernetes helpers
+# ---------------------------------------------------------------------------
+
 k8s.up:
-	@echo "Configuring Kubernetes context..."
-	@chmod +x ./scripts/k8s-up.sh
-	@./scripts/k8s-up.sh
+> @./scripts/k8s-up.sh --env-file "$(ENV_FILE)"
 
-.PHONY: k8s.bootstrap
 k8s.bootstrap:
-	@echo "Bootstrapping Minikube and MetalLB environment..."
-	@chmod +x ./scripts/preflight_and_bootstrap.sh
-	@./scripts/preflight_and_bootstrap.sh --env-file "$(ENV_FILE)" --assume-yes
+> @./scripts/preflight_and_bootstrap.sh --env-file "$(ENV_FILE)"
 
-.PHONY: k8s.smoketest
 k8s.smoketest:
-	@echo "Running Kubernetes smoketest..."
-	@chmod +x ./scripts/k8s-smoketest.sh
-	@./scripts/k8s-smoketest.sh --env-file "$(ENV_FILE)"
+> @./scripts/k8s-smoketest.sh --env-file "$(ENV_FILE)"
 
-.PHONY: status
+# ---------------------------------------------------------------------------
+# Status helpers
+# ---------------------------------------------------------------------------
+
 status:
-	@chmod +x ./scripts/resume-state.sh
-	@./scripts/resume-state.sh --env-file "$(ENV_FILE)"
+> @./scripts/resume-state.sh --env-file "$(ENV_FILE)"
 
-.PHONY: up
 up: net.ensure preflight pf.config pf.install pf.smoketest k8s.up k8s.smoketest status
-	@echo "Homelab bootstrap complete."
-.PHONY: test
-test:
-	@echo "Running Bats test suite..."
-	@$(BATS) tests/bats
-	@./scripts/tests/retry_test.sh
+> @echo "Homelab bootstrap complete."
 
-.PHONY: lint
+# ---------------------------------------------------------------------------
+# Documentation and QA
+# ---------------------------------------------------------------------------
+
+docs:
+> @echo "Building documentation with MkDocs..."
+> @mkdocs build
+
 lint:
-	@echo "Running lint checks..."
-	@missing_tools=0
-	@for tool in shellcheck shfmt yamllint actionlint; do \
-		if ! command -v "$$tool" >/dev/null 2>&1; then \
-			echo "ERROR: $$tool is required but not installed." >&2; \
-			missing_tools=1; \
-		fi; \
-	done; \
-	if [[ $$missing_tools -ne 0 ]]; then \
-		exit 1; \
-	fi
-	@echo "Running shellcheck..."
-	@mapfile -t shellcheck_files < <(git ls-files -- '*.sh')
-	@if (( $${#shellcheck_files[@]} )); then \
-		shellcheck --severity=error --exclude=SC2259 "$${shellcheck_files[@]}"; \
-		echo "shellcheck passed."; \
-	else \
-		echo "No shell scripts found for shellcheck."; \
-	fi
-	@echo "Running shfmt..."
-	@mapfile -t shfmt_files < <(git ls-files -- ':(glob)scripts/**/*.sh' ':(top,glob)*.sh' ':(exclude)scripts/k8s-up.sh' ':(exclude)scripts/uranus_homelab_apps.sh')
-	@if (( $${#shfmt_files[@]} )); then \
-		if ! shfmt -d -i 2 "$${shfmt_files[@]}"; then \
-			echo "ERROR: shfmt found formatting issues. Run 'shfmt -w -i 2' to fix." >&2; \
-			exit 1; \
-		fi; \
-		echo "shfmt passed."; \
-	else \
-		echo "No shell scripts found for shfmt."; \
-	fi
-	@echo "Running yamllint..."
-	@mapfile -t yaml_files < <(git ls-files -- '*.yml' '*.yaml')
-	@if (( $${#yaml_files[@]} )); then \
-		yamllint "$${yaml_files[@]}"; \
-		echo "yamllint passed."; \
-	else \
-		echo "No YAML files found for yamllint."; \
-	fi
-	@echo "Running actionlint..."
-	@actionlint
-	@echo "actionlint passed."
-.PHONY: ci
-ci: lint test
+> @echo "Running lint checks..."
+> @missing_tools=0
+> @for tool in shellcheck shfmt yamllint actionlint; do \
+> if ! command -v "$$tool" >/dev/null 2>&1; then \
+> echo "ERROR: $$tool is required but not installed." >&2; \
+> missing_tools=1; \
+> fi; \
+> done; \
+> if [[ $$missing_tools -ne 0 ]]; then \
+> exit 1; \
+> fi
+> @echo "Running shellcheck..."
+> @mapfile -t shellcheck_files < <(git ls-files -- '*.sh')
+> @if (( $${#shellcheck_files[@]} )); then \
+> shellcheck --severity=error --exclude=SC2259 "$$\{shellcheck_files[@]}"; \
+> echo "shellcheck passed."; \
+> else \
+> echo "No shell scripts found for shellcheck."; \
+> fi
+> @echo "Running shfmt..."
+> @mapfile -t shfmt_files < <(git ls-files -- ':(glob)scripts/**/*.sh' ':(top,glob)*.sh' ':(exclude)scripts/k8s-up.sh' ':(exclude)scripts/uranus_homelab_apps.sh')
+> @if (( $${#shfmt_files[@]} )); then \
+> if ! shfmt -d -i 2 "$$\{shfmt_files[@]}"; then \
+> echo "ERROR: shfmt found formatting issues. Run 'shfmt -w -i 2' to fix." >&2; \
+> exit 1; \
+> fi; \
+> echo "shfmt passed."; \
+> else \
+> echo "No shell scripts found for shfmt."; \
+> fi
+> @echo "Running yamllint..."
+> @mapfile -t yaml_files < <(git ls-files -- '*.yml' '*.yaml')
+> @if (( $${#yaml_files[@]} )); then \
+> yamllint "$$\{yaml_files[@]}"; \
+> echo "yamllint passed."; \
+> else \
+> echo "No YAML files found for yamllint."; \
+> fi
+> @echo "Running actionlint..."
+> @actionlint
+> @echo "actionlint passed."
 
+test:
+> @echo "Running Bats test suite..."
+> @"$(BATS)" tests/bats
+> @./scripts/tests/retry_test.sh
+
+ci: lint test

--- a/scripts/net-ensure.sh
+++ b/scripts/net-ensure.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+COMMON_LIB="${REPO_ROOT}/scripts/lib/common.sh"
+if [[ -f "${COMMON_LIB}" ]]; then
+  # shellcheck source=scripts/lib/common.sh
+  source "${COMMON_LIB}"
+else
+  FALLBACK_LIB="${REPO_ROOT}/scripts/lib/common_fallback.sh"
+  if [[ -f "${FALLBACK_LIB}" ]]; then
+    # shellcheck source=scripts/lib/common_fallback.sh
+    source "${FALLBACK_LIB}"
+  else
+    echo "Unable to locate scripts/lib/common.sh or fallback helpers" >&2
+    exit 70
+  fi
+fi
+
+readonly EX_OK=0
+readonly EX_USAGE=64
+readonly EX_CONFIG=78
+
+ENV_FILE_OVERRIDE=""
+ALLOW_CREATE=true
+SUDO=()
+
+usage() {
+  cat <<'USAGE'
+Usage: net-ensure.sh [OPTIONS]
+
+Ensure the pfSense WAN and LAN bridges exist on the host.
+
+Options:
+  --env-file PATH   Load configuration overrides from PATH.
+  --help            Show this help message and exit.
+
+Environment:
+  NET_CREATE        When set to "0", "false", or "no", only validate bridges
+                    without creating or modifying them. Any other value (the
+                    default) allows creation of missing bridges.
+USAGE
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --env-file)
+      if [[ $# -lt 2 ]]; then
+        usage
+        die ${EX_USAGE} "--env-file requires a path argument"
+      fi
+      ENV_FILE_OVERRIDE="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit ${EX_OK}
+      ;;
+    --)
+      shift
+      if [[ $# -gt 0 ]]; then
+        usage
+        die ${EX_USAGE} "Unexpected positional arguments: $*"
+      fi
+      ;;
+    -*)
+      usage
+      die ${EX_USAGE} "Unknown option: $1"
+      ;;
+    *)
+      usage
+      die ${EX_USAGE} "Positional arguments are not supported."
+      ;;
+    esac
+  done
+}
+
+should_allow_create() {
+  local raw=${NET_CREATE:-1}
+  case "${raw,,}" in
+  1 | true | yes | on | '')
+    ALLOW_CREATE=true
+    ;;
+  0 | false | no | off)
+    ALLOW_CREATE=false
+    ;;
+  *)
+    log_warn "Unrecognized NET_CREATE value '${raw}'. Proceeding without creating bridges."
+    ALLOW_CREATE=false
+    ;;
+  esac
+}
+
+resolve_sudo() {
+  if [[ ${ALLOW_CREATE} == false ]]; then
+    return
+  fi
+  if [[ ${EUID:-} -ne 0 ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+      SUDO=(sudo)
+    else
+      die ${EX_USAGE} "Root privileges (or sudo) are required to create or modify bridges."
+    fi
+  fi
+}
+
+load_environment() {
+  local candidates=()
+  if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
+    candidates=("${ENV_FILE_OVERRIDE}")
+  else
+    candidates=(
+      "${REPO_ROOT}/.env"
+      "${SCRIPT_DIR}/.env"
+      "/opt/homelab/.env"
+    )
+  fi
+
+  local candidate=""
+  for candidate in "${candidates[@]}"; do
+    if [[ -n ${candidate} && -f ${candidate} ]]; then
+      log_info "Loading environment from ${candidate}"
+      load_env "${candidate}" || die ${EX_CONFIG} "Failed to load ${candidate}"
+      return
+    fi
+  done
+  if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
+    die ${EX_CONFIG} "Environment file not found: ${ENV_FILE_OVERRIDE}"
+  fi
+  log_debug "No environment file found; relying on existing environment"
+}
+
+bridge_exists() {
+  local name=$1
+  ip link show dev "${name}" >/dev/null 2>&1
+}
+
+bridge_is_up() {
+  local name=$1
+  local state
+  state=$(ip -o link show dev "${name}" 2>/dev/null | awk '{print $9}') || return 1
+  [[ ${state} == "UP" ]]
+}
+
+ensure_bridge() {
+  local label=$1
+  local name=$2
+  if [[ -z ${name} ]]; then
+    die ${EX_CONFIG} "${label} bridge name is not set. Update the environment configuration."
+  fi
+
+  if bridge_exists "${name}"; then
+    log_info "${label} bridge ${name} already exists"
+  else
+    if [[ ${ALLOW_CREATE} == false ]]; then
+      die ${EX_CONFIG} "${label} bridge ${name} is missing. Re-run with NET_CREATE=1 to create it."
+    fi
+    log_info "Creating ${label} bridge ${name}"
+    "${SUDO[@]}" ip link add name "${name}" type bridge
+  fi
+
+  if bridge_is_up "${name}"; then
+    log_debug "${label} bridge ${name} is already up"
+  else
+    if [[ ${ALLOW_CREATE} == false ]]; then
+      die ${EX_CONFIG} "${label} bridge ${name} exists but is down. Re-run with NET_CREATE=1 to bring it up."
+    fi
+    log_info "Bringing up ${label} bridge ${name}"
+    "${SUDO[@]}" ip link set dev "${name}" up
+  fi
+}
+
+main() {
+  need ip || die ${EX_USAGE} "ip command is required"
+  parse_args "$@"
+  should_allow_create
+  resolve_sudo
+  load_environment
+
+  local wan_mode="${WAN_MODE:-br0}"
+  local wan_bridge="${PF_WAN_BRIDGE:-}"
+  local lan_bridge="${PF_LAN_BRIDGE:-}"
+
+  if [[ ${wan_mode} == br0 ]]; then
+    ensure_bridge "WAN" "${wan_bridge}"
+  else
+    log_info "WAN_MODE=${wan_mode}; skipping WAN bridge checks"
+  fi
+
+  ensure_bridge "LAN" "${lan_bridge}"
+
+  log_info "Bridge validation complete"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- refactor the Makefile to export ENV_FILE, add the doctor target, refresh the help text, and pass --env-file to all automation scripts
- route net.ensure through a new net-ensure.sh helper that honours NET_CREATE while validating/creating pfSense bridges

## Testing
- make -n up
- make -n doctor

------
https://chatgpt.com/codex/tasks/task_e_68d170d8f1f48323a9ad288731aa0f6a