### PR TITLE
Refactor scripts to share common env loader

### DIFF
--- a/scripts/common-env.sh
+++ b/scripts/common-env.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  echo "scripts/common-env.sh is a helper library and must be sourced." >&2
+  exit 64
+fi
+
+if [[ -n ${_HOMELAB_COMMON_ENV_SH_SOURCED:-} ]]; then
+  return 0
+fi
+readonly _HOMELAB_COMMON_ENV_SH_SOURCED=1
+
+HOMELAB_COMMON_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOMELAB_REPO_ROOT="$(cd "${HOMELAB_COMMON_ENV_DIR}/.." && pwd)"
+export HOMELAB_COMMON_ENV_DIR
+export HOMELAB_REPO_ROOT
+
+: "${REPO_ROOT:=${HOMELAB_REPO_ROOT}}"
+
+readonly HOMELAB_ROOT="/opt/homelab"
+readonly HOMELAB_ENV_DEFAULT="${HOMELAB_ROOT}/.env"
+readonly HOMELAB_PFSENSE_ROOT="${HOMELAB_ROOT}/pfsense"
+readonly HOMELAB_PFSENSE_CONFIG_DIR="${HOMELAB_PFSENSE_ROOT}/config"
+readonly HOMELAB_BACKUP_DIR="${HOMELAB_ROOT}/backups"
+readonly HOMELAB_STATE_DIR="${HOMELAB_ROOT}/state"
+
+: "${EX_OK:=0}"
+: "${EX_USAGE:=64}"
+: "${EX_UNAVAILABLE:=69}"
+: "${EX_SOFTWARE:=70}"
+: "${EX_OSERR:=71}"
+: "${EX_CONFIG:=78}"
+
+COMMON_ENV_LIB="${HOMELAB_REPO_ROOT}/scripts/lib/common.sh"
+if [[ -f ${COMMON_ENV_LIB} ]]; then
+  # shellcheck source=scripts/lib/common.sh
+  source "${COMMON_ENV_LIB}"
+elif [[ -f ${HOMELAB_REPO_ROOT}/scripts/lib/common_fallback.sh ]] ; then
+  # shellcheck source=scripts/lib/common_fallback.sh
+  source "${HOMELAB_REPO_ROOT}/scripts/lib/common_fallback.sh"
+else
+  echo "homelab: unable to locate scripts/lib/common.sh" >&2
+  return "${EX_SOFTWARE}"
+fi
+
+: "${HOMELAB_ENV_FILE:=}"
+declare -ag HOMELAB_BRIDGES_READY=()
+declare -ag HOMELAB_BRIDGES_ISSUES=()
+
+# Default variables shown by dump_effective_env when no explicit list is provided.
+# shellcheck disable=SC2034
+HOMELAB_ENV_SUMMARY_VARS=(
+  LABZ_DOMAIN
+  LAB_DOMAIN_BASE
+  LABZ_TRAEFIK_HOST
+  LABZ_NEXTCLOUD_HOST
+  LABZ_JELLYFIN_HOST
+  LABZ_METALLB_RANGE
+  PF_WAN_BRIDGE
+  PF_LAN_BRIDGE
+  WAN_MODE
+  LAN_CIDR
+  LAN_GW_IP
+  LAN_DHCP_FROM
+  LAN_DHCP_TO
+  METALLB_POOL_START
+  METALLB_POOL_END
+  TRAEFIK_LOCAL_IP
+  WORK_ROOT
+  PG_BACKUP_HOSTPATH
+)
+
+log() {
+  local level=${1:-info}
+  shift || true
+  case "${level,,}" in
+    trace) log_trace "$@" ;;
+    debug) log_debug "$@" ;;
+    info) log_info "$@" ;;
+    warn|warning) log_warn "$@" ;;
+    error|err) log_error "$@" ;;
+    fatal|crit|critical) log_fatal "$@" ;;
+    *) log_info "${level} $*" ;;
+  esac
+}
+
+info() { log_info "$@"; }
+warn() { log_warn "$@"; }
+fatal() { die "$@"; }
+
+require_cmd() {
+  if [[ $# -eq 0 ]]; then
+    log_warn "require_cmd called without arguments"
+    return 64
+  fi
+  local missing=()
+  local cmd
+  for cmd in "$@"; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      missing+=("${cmd}")
+    fi
+  done
+  if (( ${#missing[@]} > 0 )); then
+    log_error "Missing required commands: ${missing[*]}"
+    return 1
+  fi
+  return 0
+}
+
+load_env() {
+  local override=""
+  local required=false
+  local silent=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env-file|-e)
+        if [[ $# -lt 2 ]]; then
+          log_error "load_env: $1 requires a path argument"
+          return "${EX_USAGE}"
+        fi
+        override="$2"
+        shift 2
+        ;;
+      --env-file=*|-e=*)
+        override="${1#*=}"
+        shift
+        ;;
+      --required)
+        required=true
+        shift
+        ;;
+      --silent)
+        silent=true
+        shift
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        if [[ -z ${override} ]]; then
+          override="$1"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  if [[ -z ${override} && -n ${ENV_FILE:-} ]]; then
+    override="${ENV_FILE}"
+  fi
+
+  local -a candidates=()
+  if [[ -n ${override} ]]; then
+    candidates=("${override}")
+  else
+    candidates=(
+      "${PWD}/.env"
+      "${REPO_ROOT}/.env"
+      "${HOMELAB_ENV_DEFAULT}"
+      "${REPO_ROOT}/.env.example"
+    )
+  fi
+
+  local candidate=""
+  for candidate in "${candidates[@]}"; do
+    if [[ -f ${candidate} ]]; then
+      if [[ ${silent} != true ]]; then
+        info "Loading environment from ${candidate}"
+      fi
+      local previous_opts
+      previous_opts=$(set +o)
+      set -a
+      # shellcheck disable=SC1090
+      source "${candidate}"
+      eval "${previous_opts}"
+      HOMELAB_ENV_FILE="${candidate}"
+      export HOMELAB_ENV_FILE
+      return 0
+    fi
+  done
+
+  HOMELAB_ENV_FILE=""
+
+  if [[ -n ${override} ]]; then
+    if [[ ${required} == true ]]; then
+      return 1
+    fi
+    warn "Environment file not found: ${override}"
+    return 1
+  fi
+
+  if [[ ${required} == true ]]; then
+    return 1
+  fi
+
+  if [[ ${silent} != true ]]; then
+    warn "No environment file found (checked: ${candidates[*]})"
+  fi
+  return 1
+}
+
+_homelab_record_bridge_state() {
+  local role=$1
+  local bridge=$2
+
+  if [[ -z ${bridge} ]]; then
+    HOMELAB_BRIDGES_ISSUES+=("${role}:<unset>:missing")
+    warn "PF_${role}_BRIDGE is not set"
+    return
+  fi
+
+  if ! ip link show dev "${bridge}" >/dev/null 2>&1; then
+    HOMELAB_BRIDGES_ISSUES+=("${role}:${bridge}:missing")
+    warn "${role} bridge ${bridge} not found"
+    return
+  fi
+
+  local state
+  state=$(ip -o link show dev "${bridge}" 2>/dev/null | awk '{print $9}')
+  if [[ ${state} != "UP" ]]; then
+    HOMELAB_BRIDGES_ISSUES+=("${role}:${bridge}:${state:-down}")
+    warn "${role} bridge ${bridge} is ${state:-down}"
+    return
+  fi
+
+  HOMELAB_BRIDGES_READY+=("${role}:${bridge}")
+  info "${role} bridge ${bridge} is present and up"
+}
+
+validate_bridges() {
+  HOMELAB_BRIDGES_READY=()
+  HOMELAB_BRIDGES_ISSUES=()
+
+  if ! command -v ip >/dev/null 2>&1; then
+    warn "ip command not available; skipping bridge validation"
+    return 2
+  fi
+
+  local wan_mode=${WAN_MODE:-br0}
+  if [[ ${wan_mode} == "br0" ]]; then
+    _homelab_record_bridge_state "WAN" "${PF_WAN_BRIDGE:-}"
+  else
+    info "WAN_MODE=${wan_mode}; skipping WAN bridge validation"
+  fi
+  _homelab_record_bridge_state "LAN" "${PF_LAN_BRIDGE:-}"
+
+  if (( ${#HOMELAB_BRIDGES_ISSUES[@]} > 0 )); then
+    return 1
+  fi
+  return 0
+}
+
+dump_effective_env() {
+  local header="Effective environment"
+  local print_header=true
+  local -a vars=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-header)
+        print_header=false
+        shift
+        ;;
+      --header)
+        if [[ $# -lt 2 ]]; then
+          warn "dump_effective_env: --header requires a value"
+          shift
+        else
+          header="$2"
+          print_header=true
+          shift 2
+        fi
+        ;;
+      --)
+        shift
+        break
+        ;;
+      --*)
+        warn "dump_effective_env: unrecognized option $1"
+        shift
+        ;;
+      *)
+        vars+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [[ $# -gt 0 ]]; then
+    vars+=("$@")
+  fi
+
+  if [[ ${#vars[@]} -eq 0 ]]; then
+    vars=("${HOMELAB_ENV_SUMMARY_VARS[@]}")
+  fi
+
+  if [[ ${print_header} == true ]]; then
+    printf '\n%s\n' "${header}"
+    printf '%s\n' "$(printf '%*s' "${#header}" '' | tr ' ' '-')"
+  fi
+
+  if [[ -n ${HOMELAB_ENV_FILE} ]]; then
+    printf '  %-20s %s\n' "Environment file" "${HOMELAB_ENV_FILE}"
+  else
+    printf '  %-20s %s\n' "Environment file" "(none)"
+  fi
+
+  local var value
+  for var in "${vars[@]}"; do
+    if [[ -n ${!var-} ]]; then
+      value=${!var}
+    else
+      value="<unset>"
+    fi
+    printf '  %-20s %s\n' "${var}" "${value}"
+  done
+}
+
+ensure_dirs() {
+  local dir
+  for dir in "$@"; do
+    [[ -z ${dir} ]] && continue
+    if [[ -d ${dir} ]]; then
+      continue
+    fi
+    if mkdir -p "${dir}" >/dev/null 2>&1; then
+      info "Created directory ${dir}"
+      continue
+    fi
+    if command -v sudo >/dev/null 2>&1; then
+      info "Creating directory ${dir} with sudo"
+      if sudo mkdir -p "${dir}"; then
+        continue
+      fi
+    fi
+    fatal ${EX_OSERR} "Failed to create directory ${dir}"
+  done
+}

--- a/scripts/k8s-up.sh
+++ b/scripts/k8s-up.sh
@@ -5,20 +5,8 @@ IFS=$'\n\t'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-COMMON_LIB="${SCRIPT_DIR}/lib/common.sh"
-if [[ -f "${COMMON_LIB}" ]]; then
-  # shellcheck source=scripts/lib/common.sh
-  source "${COMMON_LIB}"
-else
-  FALLBACK_LIB="${SCRIPT_DIR}/lib/common_fallback.sh"
-  if [[ -f "${FALLBACK_LIB}" ]]; then
-    # shellcheck source=scripts/lib/common_fallback.sh
-    source "${FALLBACK_LIB}"
-  else
-    echo "Unable to locate scripts/lib/common.sh or fallback helpers" >&2
-    exit 70
-  fi
-fi
+# shellcheck source=scripts/common-env.sh
+source "${REPO_ROOT}/scripts/common-env.sh"
 
 readonly EX_OK=0
 readonly EX_USAGE=64
@@ -154,35 +142,6 @@ ensure_namespace_safe() {
     return 0
   fi
   ensure_namespace "${namespace}" || die ${EX_SOFTWARE} "Failed to ensure namespace ${namespace}"
-}
-
-load_environment() {
-  if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
-    log_info "Loading environment overrides from ${ENV_FILE_OVERRIDE}"
-    if [[ ! -f ${ENV_FILE_OVERRIDE} ]]; then
-      die ${EX_CONFIG} "Environment file not found: ${ENV_FILE_OVERRIDE}"
-    fi
-    ENV_FILE_PATH="${ENV_FILE_OVERRIDE}"
-    load_env "${ENV_FILE_OVERRIDE}" || die ${EX_CONFIG} "Failed to load ${ENV_FILE_OVERRIDE}"
-    return
-  fi
-
-  local candidates=(
-    "${REPO_ROOT}/.env"
-    "${SCRIPT_DIR}/.env"
-    "/opt/homelab/.env"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f ${candidate} ]]; then
-      log_info "Loading environment from ${candidate}"
-      ENV_FILE_PATH="${candidate}"
-      load_env "${candidate}" || die ${EX_CONFIG} "Failed to load ${candidate}"
-      return
-    fi
-  done
-  ENV_FILE_PATH=""
-  log_warn "No environment file found in default search paths"
 }
 
 require_env_vars() {
@@ -716,7 +675,15 @@ print_context_summary() {
 
 main() {
   parse_args "$@"
-  load_environment
+  if load_env "${ENV_FILE_OVERRIDE}"; then
+    ENV_FILE_PATH="${HOMELAB_ENV_FILE:-${ENV_FILE_OVERRIDE:-}}"
+  else
+    if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
+      die ${EX_CONFIG} "Environment file not found: ${ENV_FILE_OVERRIDE}"
+    fi
+    ENV_FILE_PATH=""
+    log_warn "No environment file found in default search paths"
+  fi
 
   : "${HELM_CACHE_HOME:=${XDG_CACHE_HOME:-${HOME}/.cache}/helm}"
   export HELM_CACHE_HOME

--- a/scripts/net-bridge.sh
+++ b/scripts/net-bridge.sh
@@ -5,20 +5,8 @@ IFS=$'\n\t'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-COMMON_LIB="${SCRIPT_DIR}/lib/common.sh"
-if [[ -f "${COMMON_LIB}" ]]; then
-  # shellcheck source=scripts/lib/common.sh
-  source "${COMMON_LIB}"
-else
-  FALLBACK_LIB="${SCRIPT_DIR}/lib/common_fallback.sh"
-  if [[ -f "${FALLBACK_LIB}" ]]; then
-    # shellcheck source=scripts/lib/common_fallback.sh
-    source "${FALLBACK_LIB}"
-  else
-    echo "Unable to locate scripts/lib/common.sh or fallback helpers" >&2
-    exit 70
-  fi
-fi
+# shellcheck source=scripts/common-env.sh
+source "${REPO_ROOT}/scripts/common-env.sh"
 
 readonly EX_OK=0
 readonly EX_USAGE=64
@@ -77,33 +65,6 @@ run_cmd() {
   fi
   log_debug "Executing: $(format_command "$@")"
   "$@"
-}
-
-load_environment() {
-  if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
-    log_info "Loading environment overrides from ${ENV_FILE_OVERRIDE}"
-    if [[ ! -f ${ENV_FILE_OVERRIDE} ]]; then
-      die ${EX_CONFIG} "Environment file not found: ${ENV_FILE_OVERRIDE}"
-    fi
-    load_env "${ENV_FILE_OVERRIDE}" || die ${EX_CONFIG} "Failed to load ${ENV_FILE_OVERRIDE}"
-    return
-  fi
-
-  local candidates=(
-    "${REPO_ROOT}/.env"
-    "${SCRIPT_DIR}/.env"
-    "/opt/homelab/.env"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    log_debug "Checking for environment file at ${candidate}"
-    if [[ -f ${candidate} ]]; then
-      log_info "Loading environment from ${candidate}"
-      load_env "${candidate}" || die ${EX_CONFIG} "Failed to load ${candidate}"
-      return
-    fi
-  done
-  log_debug "No environment file present in default search locations"
 }
 
 parse_nameservers() {
@@ -325,7 +286,12 @@ reboot_host() {
 
 main() {
   parse_args "$@"
-  load_environment
+  if ! load_env "${ENV_FILE_OVERRIDE}"; then
+    if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
+      die ${EX_CONFIG} "Environment file not found: ${ENV_FILE_OVERRIDE}"
+    fi
+    log_debug "No environment file present in default search locations"
+  fi
   collect_defaults
   resolve_network_values
   require_network_values

--- a/scripts/render_metallb_pool_manifest.sh
+++ b/scripts/render_metallb_pool_manifest.sh
@@ -5,20 +5,8 @@ IFS=$'\n\t'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-COMMON_LIB="${SCRIPT_DIR}/lib/common.sh"
-if [[ -f "${COMMON_LIB}" ]]; then
-  # shellcheck source=scripts/lib/common.sh
-  source "${COMMON_LIB}"
-else
-  FALLBACK_LIB="${SCRIPT_DIR}/lib/common_fallback.sh"
-  if [[ -f "${FALLBACK_LIB}" ]]; then
-    # shellcheck source=scripts/lib/common_fallback.sh
-    source "${FALLBACK_LIB}"
-  else
-    echo "Unable to locate scripts/lib/common.sh or fallback helpers" >&2
-    exit 70
-  fi
-fi
+# shellcheck source=scripts/common-env.sh
+source "${REPO_ROOT}/scripts/common-env.sh"
 
 readonly EX_OK=0
 readonly EX_USAGE=64
@@ -54,43 +42,6 @@ Examples:
   # Print the manifest without touching the repository
   ./scripts/render_metallb_pool_manifest.sh --env-file ./.env --output - --stdout
 USAGE
-}
-
-load_environment() {
-  if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
-    if [[ ! -f ${ENV_FILE_OVERRIDE} ]]; then
-      die ${EX_CONFIG} "Environment file not found: ${ENV_FILE_OVERRIDE}"
-    fi
-    log_info "Loading environment overrides from ${ENV_FILE_OVERRIDE}"
-    load_env "${ENV_FILE_OVERRIDE}" || die ${EX_CONFIG} "Failed to load ${ENV_FILE_OVERRIDE}"
-    ENV_FILE_PATH="${ENV_FILE_OVERRIDE}"
-    return
-  fi
-
-  local candidates=(
-    "${REPO_ROOT}/.env"
-    "${SCRIPT_DIR}/.env"
-    "/opt/homelab/.env"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    if [[ -f ${candidate} ]]; then
-      log_info "Loading environment from ${candidate}"
-      load_env "${candidate}" || die ${EX_CONFIG} "Failed to load ${candidate}"
-      ENV_FILE_PATH="${candidate}"
-      return
-    fi
-  done
-
-  local fallback="${REPO_ROOT}/.env.example"
-  if [[ -f ${fallback} ]]; then
-    log_info "Falling back to ${fallback}"
-    load_env "${fallback}" || die ${EX_CONFIG} "Failed to load ${fallback}"
-    ENV_FILE_PATH="${fallback}"
-    return
-  fi
-
-  die ${EX_CONFIG} "Unable to locate an environment file. Use --env-file to specify one."
 }
 
 parse_args() {
@@ -155,7 +106,14 @@ parse_args() {
 
 main() {
   parse_args "$@"
-  load_environment
+  if load_env "${ENV_FILE_OVERRIDE}"; then
+    ENV_FILE_PATH="${HOMELAB_ENV_FILE:-${ENV_FILE_OVERRIDE:-}}"
+  else
+    if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
+      die ${EX_CONFIG} "Environment file not found: ${ENV_FILE_OVERRIDE}"
+    fi
+    die ${EX_CONFIG} "Unable to locate an environment file. Use --env-file to specify one."
+  fi
 
   if [[ -z ${METALLB_POOL_START:-} || -z ${METALLB_POOL_END:-} ]]; then
     local env_source=${ENV_FILE_PATH:-environment}

--- a/scripts/resume-state.sh
+++ b/scripts/resume-state.sh
@@ -3,20 +3,10 @@ set -euo pipefail
 IFS=$'\n\t'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-COMMON_LIB="${SCRIPT_DIR}/lib/common.sh"
-if [[ -f "${COMMON_LIB}" ]]; then
-  # shellcheck source=scripts/lib/common.sh
-  source "${COMMON_LIB}"
-else
-  FALLBACK_LIB="${SCRIPT_DIR}/lib/common_fallback.sh"
-  if [[ -f "${FALLBACK_LIB}" ]]; then
-    # shellcheck source=scripts/lib/common_fallback.sh
-    source "${FALLBACK_LIB}"
-  else
-    echo "Unable to locate scripts/lib/common.sh or fallback helpers" >&2
-    exit 70
-  fi
-fi
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/common-env.sh
+source "${REPO_ROOT}/scripts/common-env.sh"
 
 readonly EX_OK=0
 readonly EX_USAGE=64
@@ -39,34 +29,6 @@ Exit codes:
   0  Success.
   64 Usage error (invalid CLI arguments).
 USAGE
-}
-
-load_environment() {
-  if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
-    log_info "Loading environment overrides from ${ENV_FILE_OVERRIDE}"
-    if [[ ! -f ${ENV_FILE_OVERRIDE} ]]; then
-      die ${EX_USAGE} "Environment file not found: ${ENV_FILE_OVERRIDE}"
-    fi
-    load_env "${ENV_FILE_OVERRIDE}" || die ${EX_USAGE} "Failed to load ${ENV_FILE_OVERRIDE}"
-    return
-  fi
-  local parent_root
-  parent_root="$(cd "${SCRIPT_DIR}/.." && pwd)"
-  local candidates=(
-    "${parent_root}/.env"
-    "${SCRIPT_DIR}/.env"
-    "/opt/homelab/.env"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    log_debug "Checking for environment file at ${candidate}"
-    if [[ -f ${candidate} ]]; then
-      log_info "Loading environment from ${candidate}"
-      load_env "${candidate}" || die ${EX_USAGE} "Failed to load ${candidate}"
-      return
-    fi
-  done
-  log_debug "No environment file present in default search locations"
 }
 
 parse_args() {
@@ -113,7 +75,12 @@ parse_args() {
 
 main() {
   parse_args "$@"
-  load_environment
+  if ! load_env "${ENV_FILE_OVERRIDE}"; then
+    if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
+      die ${EX_USAGE} "Environment file not found: ${ENV_FILE_OVERRIDE}"
+    fi
+    log_debug "No environment file present in default search locations"
+  fi
   : "${URANUS_STATE_FILE:=/root/.uranus_bootstrap_state}"
   STATE_FILE="${STATE_FILE:-${URANUS_STATE_FILE}}"
   if [[ -f ${STATE_FILE} ]]; then

--- a/scripts/uranus_homelab.sh
+++ b/scripts/uranus_homelab.sh
@@ -5,20 +5,8 @@ IFS=$'\n\t'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-COMMON_LIB="${SCRIPT_DIR}/lib/common.sh"
-if [[ -f "${COMMON_LIB}" ]]; then
-  # shellcheck source=scripts/lib/common.sh
-  source "${COMMON_LIB}"
-else
-  FALLBACK_LIB="${SCRIPT_DIR}/lib/common_fallback.sh"
-  if [[ -f "${FALLBACK_LIB}" ]]; then
-    # shellcheck source=scripts/lib/common_fallback.sh
-    source "${FALLBACK_LIB}"
-  else
-    echo "Unable to locate scripts/lib/common.sh or fallback helpers" >&2
-    exit 70
-  fi
-fi
+# shellcheck source=scripts/common-env.sh
+source "${REPO_ROOT}/scripts/common-env.sh"
 
 readonly EX_OK=0
 readonly EX_USAGE=64
@@ -29,7 +17,6 @@ readonly EX_CONFIG=78
 ASSUME_YES=false
 DELETE_PREVIOUS=false
 ENV_FILE_OVERRIDE=""
-ENV_FILE_PATH=""
 DRY_RUN=false
 CHECK_ONLY=false
 CONTEXT_ONLY=false
@@ -74,33 +61,24 @@ format_command() {
 }
 
 load_environment() {
+  local -a args=()
+
   if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
-    log_info "Loading environment overrides from ${ENV_FILE_OVERRIDE}"
     if [[ ! -f ${ENV_FILE_OVERRIDE} ]]; then
       die ${EX_CONFIG} "Environment file not found: ${ENV_FILE_OVERRIDE}"
     fi
-    ENV_FILE_PATH="${ENV_FILE_OVERRIDE}"
-    load_env "${ENV_FILE_OVERRIDE}" || die ${EX_CONFIG} "Failed to load ${ENV_FILE_OVERRIDE}"
-    return
+    args+=(--env-file "${ENV_FILE_OVERRIDE}")
   fi
 
-  local candidates=(
-    "${REPO_ROOT}/.env"
-    "${SCRIPT_DIR}/.env"
-    "/opt/homelab/.env"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    log_debug "Checking for environment file at ${candidate}"
-    if [[ -f ${candidate} ]]; then
-      log_info "Loading environment from ${candidate}"
-      ENV_FILE_PATH="${candidate}"
-      load_env "${candidate}" || die ${EX_CONFIG} "Failed to load ${candidate}"
-      return
+  if ! load_env "${args[@]}"; then
+    if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
+      die ${EX_CONFIG} "Failed to load environment file: ${ENV_FILE_OVERRIDE}"
     fi
-  done
-  ENV_FILE_PATH=""
-  log_debug "No environment file present in default search locations"
+    warn "Continuing without an environment file"
+    return 1
+  fi
+
+  return 0
 }
 
 parse_args() {
@@ -164,8 +142,8 @@ parse_args() {
 build_common_args() {
   local -n target=$1
   target=()
-  if [[ -n ${ENV_FILE_PATH} ]]; then
-    target+=("--env-file" "${ENV_FILE_PATH}")
+  if [[ -n ${HOMELAB_ENV_FILE:-} ]]; then
+    target+=("--env-file" "${HOMELAB_ENV_FILE}")
   fi
   if [[ ${ASSUME_YES} == true ]]; then
     target+=("--assume-yes")
@@ -222,7 +200,7 @@ run_pfsense_ztp() {
   build_common_args common_args
 
   local env_file
-  env_file="${ENV_FILE_PATH:-./.env}"
+  env_file="${HOMELAB_ENV_FILE:-./.env}"
 
   local pf_args=(
     "--env-file" "${env_file}"

--- a/scripts/uranus_nuke_and_bootstrap.sh
+++ b/scripts/uranus_nuke_and_bootstrap.sh
@@ -5,35 +5,17 @@ IFS=$'\n\t'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-COMMON_LIB="${SCRIPT_DIR}/lib/common.sh"
-if [[ -f "${COMMON_LIB}" ]]; then
-  # shellcheck source=scripts/lib/common.sh
-  source "${COMMON_LIB}"
-else
-  FALLBACK_LIB="${SCRIPT_DIR}/lib/common_fallback.sh"
-  if [[ -f "${FALLBACK_LIB}" ]]; then
-    # shellcheck source=scripts/lib/common_fallback.sh
-    source "${FALLBACK_LIB}"
-  else
-    echo "Unable to locate scripts/lib/common.sh or fallback helpers" >&2
-    exit 70
-  fi
-fi
+# shellcheck source=scripts/common-env.sh
+source "${REPO_ROOT}/scripts/common-env.sh"
 
-readonly EX_OK=0
-readonly EX_TIMEOUT=4
-readonly EX_USAGE=64
-readonly EX_UNAVAILABLE=69
-readonly EX_SOFTWARE=70
-readonly EX_TEMPFAIL=75
-readonly EX_CONFIG=78
+: "${EX_TIMEOUT:=4}"
+: "${EX_TEMPFAIL:=75}"
 
 ASSUME_YES=false
 DELETE_PREVIOUS=false
 DRY_RUN=false
 CONTEXT_ONLY=false
 ENV_FILE_OVERRIDE=""
-ENV_FILE_PATH=""
 HOLD_PORT_FORWARD=false
 
 REGISTRY_LOCAL_PORT=5000
@@ -77,33 +59,24 @@ run_cmd() {
 }
 
 load_environment() {
+  local -a args=()
+
   if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
-    log_info "Loading environment overrides from ${ENV_FILE_OVERRIDE}"
     if [[ ! -f ${ENV_FILE_OVERRIDE} ]]; then
       die ${EX_CONFIG} "Environment file not found: ${ENV_FILE_OVERRIDE}"
     fi
-    ENV_FILE_PATH="${ENV_FILE_OVERRIDE}"
-    load_env "${ENV_FILE_OVERRIDE}" || die ${EX_CONFIG} "Failed to load ${ENV_FILE_OVERRIDE}"
-    return
+    args+=(--env-file "${ENV_FILE_OVERRIDE}")
   fi
 
-  local candidates=(
-    "${REPO_ROOT}/.env"
-    "${SCRIPT_DIR}/.env"
-    "/opt/homelab/.env"
-  )
-  local candidate
-  for candidate in "${candidates[@]}"; do
-    log_debug "Checking for environment file at ${candidate}"
-    if [[ -f ${candidate} ]]; then
-      log_info "Loading environment from ${candidate}"
-      ENV_FILE_PATH="${candidate}"
-      load_env "${candidate}" || die ${EX_CONFIG} "Failed to load ${candidate}"
-      return
+  if ! load_env "${args[@]}"; then
+    if [[ -n ${ENV_FILE_OVERRIDE} ]]; then
+      die ${EX_CONFIG} "Failed to load environment file: ${ENV_FILE_OVERRIDE}"
     fi
-  done
-  ENV_FILE_PATH=""
-  log_debug "No environment file present in default search locations"
+    warn "Continuing without an environment file"
+    return 1
+  fi
+
+  return 0
 }
 
 parse_args() {


### PR DESCRIPTION
## Summary
- add scripts/common-env.sh to centralize homelab logging helpers, environment loading, and common paths
- update automation scripts to source the shared helper and drop bespoke environment parsing, including the Uranus workflows and doctor checks
- ensure supporting functions (bridge validation, directory creation, etc.) use the shared constants and helpers throughout the tree

## Testing
- bash -n scripts/uranus_homelab.sh
- bash -n scripts/uranus_homelab_one.sh
- bash -n scripts/uranus_nuke_and_bootstrap.sh
- bash -n scripts/doctor.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1aff66f148323932b87e3172e2559